### PR TITLE
Improve Linux installer automation

### DIFF
--- a/README-linux.md
+++ b/README-linux.md
@@ -11,8 +11,7 @@ This bundle is ready for **Debian/Ubuntu** with **systemd**. It includes:
 ## Quick Install
 ```bash
 sudo bash scripts/install-linux.sh
-# then edit /opt/rustadmin/backend/.env and restart if needed:
-# sudo systemctl restart rustadmin-backend
+# follow the prompts to configure the backend environment
 ```
 
 ## Uninstall


### PR DESCRIPTION
## Summary
- ensure the Linux installer enforces root execution, locates the project root, and installs required OS packages
- copy application files safely without clobbering runtime configuration and automate backend dependency installation
- automatically configure systemd and nginx services with proper permissions for a hands-off deployment
- prompt for backend environment values so the service starts with the desired database, auth secret, and optional Steam API key

## Testing
- bash -n scripts/install-linux.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1afff6dc48331b5d85d8a276e8264