### PR TITLE
Add multi-server monitoring, access controls, and refreshed panel UI

### DIFF
--- a/README-linux.md
+++ b/README-linux.md
@@ -44,3 +44,16 @@ MYSQL_DATABASE=rustadmin
 ```
 
 Set `STEAM_API_KEY=...` for Steam enrichment.
+
+## Access control
+
+- On first boot the panel seeds an `admin / admin123` account; sign in and change it immediately.
+- Admins can invite teammates from the **Team access** card in the UI — accounts can be promoted or removed at any time.
+- To allow public self-registration set `ALLOW_REGISTRATION=true` in the backend environment (defaults to disabled).
+- Set `JWT_SECRET` to a long random value to secure issued session tokens.
+
+## Active server monitoring
+
+- The backend keeps a persistent WebSocket connection for every configured server and polls `status` on an interval.
+- Adjust the cadence with `MONITOR_INTERVAL_MS` (default `60000` ms) to balance responsiveness and RCON load.
+- Real-time health information and player counts are surfaced in the dashboard and streamed over Socket.IO to connected clients.

--- a/backend/src/auth.js
+++ b/backend/src/auth.js
@@ -1,7 +1,12 @@
 import jwt from 'jsonwebtoken';
 
-export function signToken(userId, secret) {
-  return jwt.sign({ uid: userId }, secret, { expiresIn: '7d' });
+export function signToken(user, secret) {
+  const payload = {
+    uid: user.id,
+    role: user.role || 'user',
+    username: user.username
+  };
+  return jwt.sign(payload, secret, { expiresIn: '7d' });
 }
 
 export function authMiddleware(secret) {
@@ -17,4 +22,9 @@ export function authMiddleware(secret) {
       return res.status(401).json({ error: 'invalid_token' });
     }
   };
+}
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  next();
 }

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -27,7 +27,7 @@ export async function initDb() {
   const count = await db.countUsers();
   if (count === 0) {
     const hash = bcrypt.hashSync('admin123', 10);
-    await db.createUser('admin', hash);
+    await db.createUser({ username: 'admin', password_hash: hash, role: 'admin' });
     console.log('Created default admin: admin / admin123');
   }
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,7 +5,7 @@ import http from 'http';
 import { Server as IOServer } from 'socket.io';
 import bcrypt from 'bcrypt';
 import { db, initDb } from './db/index.js';
-import { authMiddleware, signToken } from './auth.js';
+import { authMiddleware, signToken, requireAdmin } from './auth.js';
 import { RustWebRcon } from './rcon.js';
 
 const app = express();
@@ -14,66 +14,332 @@ const io = new IOServer(server, { cors: { origin: process.env.CORS_ORIGIN?.split
 
 const PORT = parseInt(process.env.PORT || '8787', 10);
 const BIND = process.env.BIND || '0.0.0.0';
+const JWT_SECRET = process.env.JWT_SECRET || 'dev';
+const ALLOW_REGISTRATION = (process.env.ALLOW_REGISTRATION || '').toLowerCase() === 'true';
+const MONITOR_INTERVAL = Math.max(parseInt(process.env.MONITOR_INTERVAL_MS || '60000', 10), 15000);
 
 app.use(express.json({ limit: '1mb' }));
 app.use(cors({ origin: (origin, cb) => cb(null, true), credentials: true }));
 
 await initDb();
 
+const auth = authMiddleware(JWT_SECRET);
 const rconMap = new Map();
+const statusMap = new Map();
+let monitoring = false;
+let monitorTimer = null;
+
+function recordStatus(id, data) {
+  const key = Number(id);
+  const payload = { id: key, ...data };
+  statusMap.set(key, payload);
+  io.to(`srv:${key}`).emit('status', payload);
+  return payload;
+}
+
+function getStatusSnapshot() {
+  const out = {};
+  for (const [id, data] of statusMap.entries()) out[id] = data;
+  return out;
+}
+
+function closeRcon(id) {
+  const key = Number(id);
+  const client = rconMap.get(key);
+  if (client) {
+    try { client.close(); } catch { /* ignore */ }
+    rconMap.delete(key);
+  }
+}
+
 function getOrCreateRcon(row) {
-  if (rconMap.has(row.id)) return rconMap.get(row.id);
+  const key = Number(row.id);
+  if (rconMap.has(key)) return rconMap.get(key);
   const client = new RustWebRcon({ host: row.host, port: row.port, password: row.password, tls: !!row.tls });
-  client.on('message', (msg) => io.to(`srv:${row.id}`).emit('console', msg));
-  client.on('error', (e) => io.to(`srv:${row.id}`).emit('error', e.message || String(e)));
-  rconMap.set(row.id, client);
+  client.on('message', (msg) => io.to(`srv:${key}`).emit('console', msg));
+  client.on('error', (e) => {
+    const message = e?.message || String(e);
+    io.to(`srv:${key}`).emit('error', message);
+    recordStatus(key, { ok: false, lastCheck: new Date().toISOString(), error: message });
+  });
+  client.on('close', () => {
+    rconMap.delete(key);
+    recordStatus(key, { ok: false, lastCheck: new Date().toISOString(), error: 'connection_closed' });
+  });
+  rconMap.set(key, client);
   return client;
 }
 
+function parseStatusMessage(message) {
+  const info = {
+    raw: message,
+    hostname: null,
+    players: null,
+    queued: null,
+    sleepers: null
+  };
+  if (!message) return info;
+  const lines = message.split(/\r?\n/);
+  for (const line of lines) {
+    const hostnameMatch = line.match(/hostname\s*[:=]\s*(.+)$/i);
+    if (hostnameMatch) info.hostname = hostnameMatch[1].trim();
+    const playersMatch = line.match(/players?\s*[:=]\s*(\d+)(?:\s*\/\s*(\d+))?/i);
+    if (playersMatch) {
+      info.players = {
+        online: parseInt(playersMatch[1], 10),
+        max: playersMatch[2] ? parseInt(playersMatch[2], 10) : null
+      };
+    }
+    const queuedMatch = line.match(/queued\s*[:=]\s*(\d+)/i);
+    if (queuedMatch) info.queued = parseInt(queuedMatch[1], 10);
+    const sleepersMatch = line.match(/sleepers\s*[:=]\s*(\d+)/i);
+    if (sleepersMatch) info.sleepers = parseInt(sleepersMatch[1], 10);
+  }
+  return info;
+}
+
+async function monitorServers() {
+  if (monitoring) return;
+  monitoring = true;
+  try {
+    const list = await db.listServers();
+    const seen = new Set();
+    for (const row of list) {
+      const key = Number(row.id);
+      seen.add(key);
+      try {
+        const client = getOrCreateRcon(row);
+        const started = Date.now();
+        await client.ensure();
+        const reply = await client.command('status');
+        recordStatus(key, {
+          ok: true,
+          lastCheck: new Date().toISOString(),
+          latency: Date.now() - started,
+          details: parseStatusMessage(reply?.Message || '')
+        });
+      } catch (e) {
+        closeRcon(key);
+        recordStatus(key, {
+          ok: false,
+          lastCheck: new Date().toISOString(),
+          error: e?.message || String(e)
+        });
+      }
+    }
+    for (const key of [...statusMap.keys()]) {
+      if (!seen.has(key)) statusMap.delete(key);
+    }
+  } catch (e) {
+    console.error('monitor error', e);
+  } finally {
+    monitoring = false;
+  }
+}
+
+function triggerMonitorSoon(delay = 1000) {
+  if (monitorTimer) return;
+  monitorTimer = setTimeout(() => {
+    monitorTimer = null;
+    monitorServers().catch((err) => console.error('monitor retry error', err));
+  }, delay);
+}
+
+const monitorHandle = setInterval(() => {
+  monitorServers().catch((err) => console.error('monitor tick error', err));
+}, MONITOR_INTERVAL);
+if (monitorHandle.unref) monitorHandle.unref();
+monitorServers().catch((err) => console.error('initial monitor error', err));
+
+// --- Public metadata
+app.get('/api/public-config', (req, res) => {
+  res.json({ allowRegistration: ALLOW_REGISTRATION });
+});
+
 // --- Auth
-app.post('/api/login', (req, res) => {
+app.post('/api/login', async (req, res) => {
   const { username, password } = req.body || {};
   if (!username || !password) return res.status(400).json({ error: 'missing_fields' });
-  db.getUserByUsername(username).then(async (row) => {
+  try {
+    const row = await db.getUserByUsername(username);
     if (!row) return res.status(401).json({ error: 'invalid_login' });
     const ok = await bcrypt.compare(password, row.password_hash);
     if (!ok) return res.status(401).json({ error: 'invalid_login' });
-    const token = signToken(row.id, process.env.JWT_SECRET || 'dev');
-    res.json({ token, username: row.username });
-  }).catch(()=>res.status(500).json({ error: 'db_error' }));
+    const token = signToken(row, JWT_SECRET);
+    res.json({ token, username: row.username, role: row.role, id: row.id });
+  } catch (e) {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
 
-app.post('/api/password', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
+app.post('/api/register', async (req, res) => {
+  if (!ALLOW_REGISTRATION) return res.status(403).json({ error: 'registration_disabled' });
+  const { username, password } = req.body || {};
+  if (!username || !password) return res.status(400).json({ error: 'missing_fields' });
+  if (!/^[a-z0-9_\-.]{3,32}$/i.test(username)) return res.status(400).json({ error: 'invalid_username' });
+  if (password.length < 8) return res.status(400).json({ error: 'weak_password' });
+  try {
+    const existing = await db.getUserByUsername(username);
+    if (existing) return res.status(409).json({ error: 'username_taken' });
+    const hash = bcrypt.hashSync(password, 10);
+    const id = await db.createUser({ username, password_hash: hash, role: 'user' });
+    res.status(201).json({ id, username });
+  } catch (e) {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.get('/api/me', auth, async (req, res) => {
+  try {
+    const row = await db.getUser(req.user.uid);
+    if (!row) return res.status(404).json({ error: 'not_found' });
+    res.json({ id: row.id, username: row.username, role: row.role, created_at: row.created_at });
+  } catch (e) {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/password', auth, async (req, res) => {
   const { newPassword } = req.body || {};
-  if (!newPassword || newPassword.length < 6) return res.status(400).json({ error: 'weak_password' });
+  if (!newPassword || newPassword.length < 8) return res.status(400).json({ error: 'weak_password' });
   const hash = bcrypt.hashSync(newPassword, 10);
   try {
     await db.updateUserPassword(req.user.uid, hash);
     res.json({ ok: true });
-  } catch { res.status(500).json({ error: 'db_error' }); }
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.get('/api/users', auth, requireAdmin, async (req, res) => {
+  try {
+    res.json(await db.listUsers());
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/users', auth, requireAdmin, async (req, res) => {
+  const { username, password, role = 'user' } = req.body || {};
+  if (!username || !password) return res.status(400).json({ error: 'missing_fields' });
+  if (!/^[a-z0-9_\-.]{3,32}$/i.test(username)) return res.status(400).json({ error: 'invalid_username' });
+  if (password.length < 8) return res.status(400).json({ error: 'weak_password' });
+  if (!['user', 'admin'].includes(role)) return res.status(400).json({ error: 'invalid_role' });
+  try {
+    const existing = await db.getUserByUsername(username);
+    if (existing) return res.status(409).json({ error: 'username_taken' });
+    const hash = bcrypt.hashSync(password, 10);
+    const id = await db.createUser({ username, password_hash: hash, role });
+    res.status(201).json({ id, username, role });
+  } catch (e) {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.patch('/api/users/:id', auth, requireAdmin, async (req, res) => {
+  const { role } = req.body || {};
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (!role || !['user', 'admin'].includes(role)) return res.status(400).json({ error: 'invalid_role' });
+  try {
+    await db.updateUserRole(id, role);
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/users/:id/password', auth, requireAdmin, async (req, res) => {
+  const { newPassword } = req.body || {};
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (!newPassword || newPassword.length < 8) return res.status(400).json({ error: 'weak_password' });
+  const hash = bcrypt.hashSync(newPassword, 10);
+  try {
+    await db.updateUserPassword(id, hash);
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.delete('/api/users/:id', auth, requireAdmin, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (id === req.user.uid) return res.status(400).json({ error: 'cannot_delete_self' });
+  try {
+    const user = await db.getUser(id);
+    if (!user) return res.status(404).json({ error: 'not_found' });
+    if (user.role === 'admin') {
+      const count = await db.countAdmins();
+      if (count <= 1) return res.status(400).json({ error: 'last_admin' });
+    }
+    const deleted = await db.deleteUser(id);
+    res.json({ deleted });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
 
 // --- Servers CRUD
-app.get('/api/servers', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
+app.get('/api/servers', auth, async (req, res) => {
   try { res.json(await db.listServers()); } catch { res.status(500).json({ error: 'db_error' }); }
 });
-app.post('/api/servers', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
+
+app.get('/api/servers/status', auth, (req, res) => {
+  res.json(getStatusSnapshot());
+});
+
+app.get('/api/servers/:id/status', auth, (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const status = statusMap.get(id);
+  if (!status) return res.status(404).json({ error: 'not_found' });
+  res.json(status);
+});
+
+app.post('/api/servers', auth, async (req, res) => {
   const { name, host, port, password, tls } = req.body || {};
   if (!name || !host || !port || !password) return res.status(400).json({ error: 'missing_fields' });
-  try { const id = await db.createServer({name,host,port:parseInt(port,10),password,tls:tls?1:0}); res.json({ id }); }
-  catch { res.status(500).json({ error: 'db_error' }); }
+  try {
+    const id = await db.createServer({ name, host, port: parseInt(port, 10), password, tls: tls ? 1 : 0 });
+    triggerMonitorSoon();
+    res.json({ id });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
-app.patch('/api/servers/:id', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
-  try { const n = await db.updateServer(req.params.id, req.body||{}); res.json({ updated: n }); }
-  catch { res.status(500).json({ error: 'db_error' }); }
+
+app.patch('/api/servers/:id', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  try {
+    const updated = await db.updateServer(id, req.body || {});
+    if (updated) {
+      closeRcon(id);
+      triggerMonitorSoon();
+    }
+    res.json({ updated });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
-app.delete('/api/servers/:id', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
-  try { const n = await db.deleteServer(req.params.id); res.json({ deleted: n }); }
-  catch { res.status(500).json({ error: 'db_error' }); }
+
+app.delete('/api/servers/:id', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  try {
+    const deleted = await db.deleteServer(id);
+    closeRcon(id);
+    statusMap.delete(id);
+    res.json({ deleted });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
 
 // --- RCON
-app.post('/api/rcon/:id', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req, res) => {
+app.post('/api/rcon/:id', auth, async (req, res) => {
   const { id } = req.params;
   const { cmd } = req.body || {};
   if (!cmd) return res.status(400).json({ error: 'missing_cmd' });
@@ -89,24 +355,38 @@ app.post('/api/rcon/:id', authMiddleware(process.env.JWT_SECRET || 'dev'), async
 });
 
 // --- Players & Steam sync
-app.get('/api/players', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req,res) => {
-  const limit = Math.min(parseInt(req.query.limit||'100',10), 500);
-  const offset = parseInt(req.query.offset||'0',10);
-  const rows = await db.listPlayers({limit,offset});
-  res.json(rows);
+app.get('/api/players', auth, async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit || '100', 10), 500);
+  const offset = parseInt(req.query.offset || '0', 10);
+  try {
+    const rows = await db.listPlayers({ limit, offset });
+    res.json(rows);
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
-app.get('/api/players/:steamid', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req,res) => {
-  const p = await db.getPlayer(req.params.steamid);
-  if (!p) return res.status(404).json({ error: 'not_found' });
-  const events = await db.listPlayerEvents(req.params.steamid, {limit:50,offset:0});
-  res.json({ ...p, events });
+
+app.get('/api/players/:steamid', auth, async (req, res) => {
+  try {
+    const p = await db.getPlayer(req.params.steamid);
+    if (!p) return res.status(404).json({ error: 'not_found' });
+    const events = await db.listPlayerEvents(req.params.steamid, { limit: 50, offset: 0 });
+    res.json({ ...p, events });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
-app.post('/api/players/:steamid/event', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req,res) => {
+
+app.post('/api/players/:steamid/event', auth, async (req, res) => {
   const { steamid } = req.params;
   const { server_id, event, note } = req.body || {};
   if (!event) return res.status(400).json({ error: 'missing_event' });
-  await db.addPlayerEvent({ steamid, server_id, event, note });
-  res.json({ ok: true });
+  try {
+    await db.addPlayerEvent({ steamid, server_id, event, note });
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
 });
 
 async function fetchSteamProfiles(steamids, key) {
@@ -121,13 +401,13 @@ async function fetchSteamProfiles(steamids, key) {
   let bans = {};
   if (rb.ok) {
     const jb = await rb.json();
-    for (const b of (jb?.players||[])) bans[b.SteamId] = b.VACBanned ? 1 : 0;
+    for (const b of (jb?.players || [])) bans[b.SteamId] = b.VACBanned ? 1 : 0;
   }
   for (const p of players) p.vac_banned = bans[p.steamid] || 0;
   return players;
 }
 
-app.post('/api/steam/sync', authMiddleware(process.env.JWT_SECRET || 'dev'), async (req,res) => {
+app.post('/api/steam/sync', auth, async (req, res) => {
   const { steamids } = req.body || {};
   if (!Array.isArray(steamids) || steamids.length === 0) return res.status(400).json({ error: 'missing_steamids' });
   if (!process.env.STEAM_API_KEY) return res.status(400).json({ error: 'no_steam_api_key' });
@@ -151,17 +431,27 @@ app.post('/api/steam/sync', authMiddleware(process.env.JWT_SECRET || 'dev'), asy
 
 // --- sockets
 io.on('connection', (socket) => {
+  socket.emit('status-map', getStatusSnapshot());
   socket.on('join-server', async (serverId) => {
-    const row = await db.getServer(serverId);
+    const id = Number(serverId);
+    if (!Number.isFinite(id)) return;
+    const row = await db.getServer(id);
     if (!row) return;
-    socket.join(`srv:${row.id}`);
+    socket.join(`srv:${id}`);
+    const status = statusMap.get(id);
+    if (status) socket.emit('status', status);
     try {
       const client = getOrCreateRcon(row);
       await client.ensure();
-      client.command('status').catch(()=>{});
-    } catch (e) { socket.emit('error', e.message || String(e)); }
+      client.command('status').catch(() => {});
+    } catch (e) {
+      socket.emit('error', e.message || String(e));
+    }
   });
-  socket.on('leave-server', (serverId) => socket.leave(`srv:${serverId}`));
+  socket.on('leave-server', (serverId) => {
+    const id = Number(serverId);
+    socket.leave(`srv:${id}`);
+  });
 });
 
 server.listen(PORT, BIND, () => {

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1,88 +1,359 @@
 (() => {
   const $ = (sel) => document.querySelector(sel);
+
   const serversEl = $('#servers');
   const consoleEl = $('#console');
   const playersEl = $('#players');
   const loginPanel = $('#loginPanel');
   const appPanel = $('#appPanel');
   const userBox = $('#userBox');
+  const loginError = $('#loginError');
+  const registerInfo = $('#registerInfo');
+  const registerForm = $('#registerForm');
+  const registerError = $('#registerError');
+  const registerSuccess = $('#registerSuccess');
+  const btnRegister = $('#btnRegister');
+  const userCard = $('#userCard');
+  const userList = $('#userList');
+  const userFeedback = $('#userFeedback');
+  const btnSyncPlayers = $('#btnSyncPlayers');
+  const btnRefreshServers = $('#btnRefreshServers');
+  const btnClearConsole = $('#btnClearConsole');
+  const btnAddServer = $('#btnAddServer');
+  const svName = $('#svName');
+  const svHost = $('#svHost');
+  const svPort = $('#svPort');
+  const svPass = $('#svPass');
+  const svTLS = $('#svTLS');
+  const btnSend = $('#btnSend');
+  const cmdInput = $('#cmd');
+  const apiBaseInput = $('#apiBase');
+  const loginUsername = $('#username');
+  const loginPassword = $('#password');
+  const regUsername = $('#regUsername');
+  const regPassword = $('#regPassword');
+  const regConfirm = $('#regConfirm');
+  const newUserName = $('#newUserName');
+  const newUserPassword = $('#newUserPassword');
+  const newUserRole = $('#newUserRole');
+  const btnCreateUser = $('#btnCreateUser');
 
-  let API = localStorage.getItem('apiBase') || $('#apiBase').value;
-  let TOKEN = localStorage.getItem('token') || '';
+  const state = {
+    API: '',
+    TOKEN: localStorage.getItem('token') || '',
+    currentUser: null,
+    currentServerId: null,
+    serverItems: new Map(),
+    allowRegistration: false,
+    statusTimer: null
+  };
+
   let socket = null;
-  let currentServerId = null;
 
-  const ui = {
-    showLogin() { loginPanel.classList.remove('hidden'); appPanel.classList.add('hidden'); },
-    showApp() { loginPanel.classList.add('hidden'); appPanel.classList.remove('hidden'); },
-    log(line) {
-      const time = new Date().toLocaleTimeString();
-      consoleEl.textContent += `[${time}] ${line}\n`;
-      consoleEl.scrollTop = consoleEl.scrollHeight;
-    },
-    setUser(u){ userBox.textContent = u ? `Signed in as ${u}` : ''; }
+  const errorMessages = {
+    invalid_login: 'Invalid username or password.',
+    missing_fields: 'Please fill in all required fields.',
+    invalid_username: 'Usernames must be 3-32 characters and can include letters, numbers, dashes, underscores or dots.',
+    username_taken: 'That username is already taken.',
+    weak_password: 'Passwords must be at least 8 characters long.',
+    registration_disabled: 'Self-service registration is disabled.',
+    db_error: 'A database error occurred. Please try again.',
+    api_error: 'The server reported an error. Please try again.',
+    network_error: 'Unable to reach the server. Check the API URL and your connection.',
+    unauthorized: 'Your session expired. Please sign in again.',
+    last_admin: 'You cannot remove the final administrator.',
+    cannot_delete_self: 'You cannot remove your own account.'
   };
 
-  $('#btnLogin').onclick = async () => {
-    API = $('#apiBase').value.trim().replace(/\/$/, '');
-    localStorage.setItem('apiBase', API);
-    const username = $('#username').value.trim();
-    const password = $('#password').value;
-    const r = await fetch(API + '/api/login', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    const j = await r.json();
-    if (!r.ok) { alert('Login failed: ' + (j.error||r.status)); return; }
-    TOKEN = j.token; localStorage.setItem('token', TOKEN);
-    ui.setUser(j.username);
-    ui.showApp();
-    await refreshServers();
-  };
-
-  async function api(path, body=null, method='GET') {
-    const headers = { 'Authorization': 'Bearer ' + TOKEN, 'Content-Type': 'application/json' };
-    const r = await fetch(API + path, { method, headers, body: body?JSON.stringify(body):undefined });
-    if (!r.ok) throw new Error((await r.json()).error || 'api_error');
-    return await r.json();
+  function errorCode(err) {
+    if (!err) return 'unknown_error';
+    if (err instanceof Error) return err.message || 'unknown_error';
+    return String(err);
   }
 
-  async function refreshServers() {
-    serversEl.innerHTML = '';
-    const list = await api('/api/servers');
-    for (const s of list) {
-      const li = document.createElement('li');
-      const left = document.createElement('div');
-      left.innerHTML = `<div>${s.name} <span class="badge">${s.host}:${s.port}${s.tls?' (wss)':''}</span></div><div class="muted small">#${s.id}</div>`;
-      const right = document.createElement('div');
-      const btn = document.createElement('button');
-      btn.textContent = 'Connect';
-      btn.onclick = () => connectServer(s.id);
-      right.appendChild(btn);
-      li.appendChild(left); li.appendChild(right);
-      serversEl.appendChild(li);
+  function describeError(err) {
+    const code = errorCode(err);
+    return errorMessages[code] || code;
+  }
+
+  function showNotice(el, message, variant = 'error') {
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove('hidden', 'success', 'error');
+    el.classList.add('notice');
+    if (variant) el.classList.add(variant);
+  }
+
+  function hideNotice(el) {
+    if (!el) return;
+    el.classList.add('hidden');
+    el.classList.remove('success', 'error');
+    el.textContent = '';
+  }
+
+  function setApiBase(value) {
+    const trimmed = (value || '').trim().replace(/\/$/, '');
+    if (!trimmed) return;
+    state.API = trimmed;
+    if (apiBaseInput) apiBaseInput.value = trimmed;
+    localStorage.setItem('apiBase', trimmed);
+    loadPublicConfig();
+  }
+
+  async function loadPublicConfig() {
+    if (!state.API) return;
+    try {
+      const res = await fetch(state.API + '/api/public-config');
+      if (!res.ok) throw new Error('fetch_failed');
+      const data = await res.json();
+      state.allowRegistration = !!data.allowRegistration;
+      updateRegisterUi();
+    } catch {
+      state.allowRegistration = false;
+      updateRegisterUi('Unable to reach the server for registration info.');
     }
   }
 
-  async function connectServer(id) {
-    if (socket) { socket.disconnect(); socket = null; }
-    currentServerId = id;
-    socket = io(API, { transports: ['websocket'] });
+  function updateRegisterUi(message) {
+    const info = message || (state.allowRegistration ? 'Create your personal access below.' : 'Registration is disabled by the administrator.');
+    registerInfo.textContent = info;
+    if (state.allowRegistration) {
+      registerForm.classList.remove('hidden');
+      btnRegister?.removeAttribute('disabled');
+    } else {
+      registerForm.classList.add('hidden');
+      btnRegister?.setAttribute('disabled', 'disabled');
+    }
+    hideNotice(registerError);
+    hideNotice(registerSuccess);
+  }
+
+  function startStatusPolling() {
+    stopStatusPolling();
+    state.statusTimer = setInterval(() => {
+      refreshServerStatuses().catch(() => {});
+    }, 60000);
+    refreshServerStatuses().catch(() => {});
+  }
+
+  function stopStatusPolling() {
+    if (state.statusTimer) {
+      clearInterval(state.statusTimer);
+      state.statusTimer = null;
+    }
+  }
+
+  function ensureSocket() {
+    if (socket || !state.API) return socket;
+    socket = io(state.API, { transports: ['websocket'] });
     socket.on('connect', () => {
-      socket.emit('join-server', id);
-      ui.log('Joined server #' + id);
-      loadPlayers();
+      ui.log('Realtime link established.');
+      if (state.currentServerId != null) socket.emit('join-server', state.currentServerId);
+    });
+    socket.on('disconnect', () => {
+      ui.log('Realtime link lost.');
+    });
+    socket.on('status-map', (map) => applyStatusMap(map));
+    socket.on('status', (status) => {
+      if (status && typeof status.id !== 'undefined') updateServerStatus(status.id, status);
     });
     socket.on('console', (msg) => {
-      if (msg?.Message) ui.log(msg.Message.trim());
-      if (/SteamID|players connected|id :/.test(msg.Message||'')) rebuildPlayers(msg.Message);
+      if (msg?.Message) {
+        ui.log(msg.Message.trim());
+        if (/SteamID|players connected|id :/.test(msg.Message)) rebuildPlayers(msg.Message);
+      }
     });
-    socket.on('error', (e) => ui.log('Error: ' + e));
+    socket.on('error', (err) => {
+      const message = typeof err === 'string' ? err : err?.message || JSON.stringify(err);
+      ui.log('Socket error: ' + message);
+    });
+    socket.on('connect_error', (err) => {
+      const message = err?.message || 'connection error';
+      ui.log('Socket connection error: ' + message);
+    });
+    return socket;
+  }
+
+  function disconnectSocket() {
+    if (socket) {
+      try { socket.disconnect(); } catch { /* ignore */ }
+    }
+    socket = null;
+  }
+
+  function highlightSelectedServer() {
+    state.serverItems.forEach((entry, key) => {
+      const active = Number(key) === state.currentServerId;
+      entry.element.classList.toggle('active', active);
+      if (entry.connectBtn) {
+        entry.connectBtn.textContent = active ? 'Connected' : 'Connect';
+        entry.connectBtn.disabled = active;
+      }
+    });
+  }
+
+  function updateServerStatus(id, status) {
+    const key = String(id);
+    const entry = state.serverItems.get(key);
+    if (!entry) return;
+    entry.status = status;
+    const pill = entry.statusPill;
+    const details = entry.statusDetails;
+    if (!status) {
+      pill.className = 'status-pill';
+      pill.textContent = 'Unknown';
+      pill.title = '';
+      if (details) details.textContent = '';
+      return;
+    }
+    const online = !!status.ok;
+    const queued = status?.details?.queued ?? null;
+    const players = status?.details?.players?.online ?? null;
+    const maxPlayers = status?.details?.players?.max ?? null;
+    const latency = typeof status.latency === 'number' ? status.latency : null;
+    const lastCheck = status.lastCheck ? new Date(status.lastCheck).toLocaleTimeString() : null;
+
+    let pillClass = 'status-pill';
+    if (online) {
+      if (queued && queued > 0) {
+        pillClass += ' degraded';
+        pill.textContent = 'Busy';
+      } else {
+        pillClass += ' online';
+        pill.textContent = 'Online';
+      }
+    } else {
+      pillClass += ' offline';
+      pill.textContent = 'Offline';
+    }
+    pill.className = pillClass;
+    pill.title = status?.details?.hostname || status?.error || '';
+
+    if (details) {
+      const parts = [];
+      if (online && players != null) {
+        const maxInfo = maxPlayers != null ? `/${maxPlayers}` : '';
+        parts.push(`${players}${maxInfo} players`);
+      }
+      if (online && queued != null && queued > 0) parts.push(`${queued} queued`);
+      if (latency != null) parts.push(`${latency} ms`);
+      if (!online && status.error) parts.push(status.error);
+      if (lastCheck) parts.push(`checked ${lastCheck}`);
+      details.textContent = parts.join(' · ');
+      details.title = status?.details?.raw || status?.error || '';
+    }
+  }
+
+  function applyStatusMap(map) {
+    if (!map || typeof map !== 'object') return;
+    for (const [id, status] of Object.entries(map)) updateServerStatus(id, status);
+  }
+
+  async function fetchServerStatuses() {
+    try {
+      return await api('/api/servers/status');
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') {
+        handleUnauthorized();
+      } else {
+        ui.log('Unable to load server status: ' + describeError(err));
+      }
+      return {};
+    }
+  }
+
+  async function refreshServerStatuses() {
+    const statuses = await fetchServerStatuses();
+    applyStatusMap(statuses);
+  }
+
+  function renderServer(server, status) {
+    const li = document.createElement('li');
+    li.dataset.serverId = server.id;
+    const heading = document.createElement('div');
+    heading.className = 'server-heading';
+    const titleBox = document.createElement('div');
+    const strong = document.createElement('strong');
+    strong.textContent = server.name;
+    titleBox.appendChild(strong);
+    const actions = document.createElement('div');
+    actions.className = 'server-actions';
+    const statusPill = document.createElement('span');
+    statusPill.className = 'status-pill';
+    statusPill.textContent = 'Checking…';
+    const connectBtn = document.createElement('button');
+    connectBtn.className = 'accent connect';
+    connectBtn.textContent = 'Connect';
+    connectBtn.onclick = () => connectServer(server.id);
+    actions.appendChild(statusPill);
+    actions.appendChild(connectBtn);
+    heading.appendChild(titleBox);
+    heading.appendChild(actions);
+    const meta = document.createElement('div');
+    meta.className = 'server-meta';
+    const tlsLabel = server.tls ? ' · TLS' : '';
+    meta.innerHTML = `<span>${server.host}:${server.port}${tlsLabel}</span><span>ID ${server.id}</span>`;
+    const statusDetails = document.createElement('div');
+    statusDetails.className = 'status-details';
+    li.appendChild(heading);
+    li.appendChild(meta);
+    li.appendChild(statusDetails);
+    serversEl.appendChild(li);
+    state.serverItems.set(String(server.id), {
+      element: li,
+      statusPill,
+      statusDetails,
+      connectBtn,
+      data: server,
+      status: null
+    });
+    updateServerStatus(server.id, status);
+  }
+
+  async function refreshServers() {
+    try {
+      const list = await api('/api/servers');
+      serversEl.innerHTML = '';
+      state.serverItems.clear();
+      const statuses = await fetchServerStatuses();
+      for (const server of list) {
+        const status = statuses?.[server.id] || statuses?.[String(server.id)];
+        renderServer(server, status);
+      }
+      highlightSelectedServer();
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') {
+        handleUnauthorized();
+      } else {
+        ui.log('Failed to load servers: ' + describeError(err));
+      }
+    }
+  }
+
+  function connectServer(id) {
+    const numericId = Number(id);
+    if (!Number.isFinite(numericId)) return;
+    const previous = state.currentServerId;
+    if (previous === numericId && socket?.connected) return;
+    state.currentServerId = numericId;
+    highlightSelectedServer();
+    const entry = state.serverItems.get(String(numericId));
+    const name = entry?.data?.name || `Server #${numericId}`;
+    ui.clearConsole();
+    ui.log(`Connecting to ${name}…`);
+    const sock = ensureSocket();
+    if (sock && sock.connected && previous != null && previous !== numericId) {
+      sock.emit('leave-server', previous);
+    }
+    if (sock && sock.connected) {
+      sock.emit('join-server', numericId);
+    }
+    loadPlayers().catch(() => {});
   }
 
   function rebuildPlayers(text) {
     playersEl.innerHTML = '';
-    const lines = (text||'').split(/\r?\n/).filter(Boolean);
+    const lines = (text || '').split(/\r?\n/).filter(Boolean);
     for (const ln of lines) {
       const li = document.createElement('li');
       li.textContent = ln.trim();
@@ -96,36 +367,452 @@
       playersEl.innerHTML = '';
       for (const p of list) {
         const li = document.createElement('li');
-        li.innerHTML = `
-          <div>
-            <div><strong>${p.persona||p.steamid}</strong> <span class="badge">${p.country||''}</span></div>
-            <div class="small muted">${p.steamid}</div>
-          </div>
-          <div>
-            ${p.vac_banned ? '<span class="badge">VAC</span>' : ''}
-          </div>`;
+        const left = document.createElement('div');
+        const name = document.createElement('strong');
+        name.textContent = p.persona || p.steamid;
+        left.appendChild(name);
+        const small = document.createElement('div');
+        small.className = 'muted small';
+        small.textContent = p.steamid;
+        left.appendChild(small);
+        const right = document.createElement('div');
+        right.className = 'server-actions';
+        if (p.country) {
+          const badge = document.createElement('span');
+          badge.className = 'badge';
+          badge.textContent = p.country;
+          right.appendChild(badge);
+        }
+        if (p.vac_banned) {
+          const badge = document.createElement('span');
+          badge.className = 'badge';
+          badge.textContent = 'VAC';
+          right.appendChild(badge);
+        }
+        li.appendChild(left);
+        li.appendChild(right);
         playersEl.appendChild(li);
       }
-    } catch (e) { ui.log('Players load failed: ' + e.message); }
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') {
+        handleUnauthorized();
+      } else {
+        ui.log('Players load failed: ' + describeError(err));
+      }
+    }
   }
 
-  const syncBtn = document.createElement('button');
-  syncBtn.textContent = 'Sync From Steam (IDs)';
-  syncBtn.onclick = async () => {
+  const ui = {
+    showLogin() {
+      loginPanel.classList.remove('hidden');
+      appPanel.classList.add('hidden');
+    },
+    showApp() {
+      loginPanel.classList.add('hidden');
+      appPanel.classList.remove('hidden');
+    },
+    log(line) {
+      const time = new Date().toLocaleTimeString();
+      consoleEl.textContent += `[${time}] ${line}\n`;
+      consoleEl.scrollTop = consoleEl.scrollHeight;
+    },
+    clearConsole() {
+      consoleEl.textContent = '';
+    },
+    setUser(user) {
+      userBox.innerHTML = '';
+      if (!user) return;
+      const wrap = document.createElement('div');
+      const strong = document.createElement('strong');
+      strong.textContent = user.username;
+      wrap.appendChild(strong);
+      if (user.role === 'admin') {
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = 'Admin';
+        wrap.appendChild(document.createTextNode(' '));
+        wrap.appendChild(badge);
+      }
+      const btn = document.createElement('button');
+      btn.textContent = 'Sign out';
+      btn.onclick = () => logout();
+      userBox.appendChild(wrap);
+      userBox.appendChild(btn);
+    }
+  };
+
+  function logout() {
+    state.TOKEN = '';
+    state.currentUser = null;
+    state.currentServerId = null;
+    stopStatusPolling();
+    disconnectSocket();
+    localStorage.removeItem('token');
+    state.serverItems.clear();
+    serversEl.innerHTML = '';
+    playersEl.innerHTML = '';
+    ui.clearConsole();
+    ui.setUser(null);
+    userCard.classList.add('hidden');
+    hideNotice(userFeedback);
+    ui.showLogin();
+    loadPublicConfig();
+  }
+
+  function handleUnauthorized() {
+    ui.log('Session expired. Please sign in again.');
+    logout();
+  }
+
+  async function api(path, body = null, method = 'GET') {
+    if (!state.TOKEN) throw new Error('unauthorized');
+    const headers = { 'Authorization': 'Bearer ' + state.TOKEN };
+    const opts = { method, headers };
+    if (body !== null) {
+      headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    }
+    let res;
+    try {
+      res = await fetch(state.API + path, opts);
+    } catch (err) {
+      if (err instanceof TypeError) throw new Error('network_error');
+      throw err;
+    }
+    let data = {};
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) data = await res.json();
+    if (res.status === 401) throw new Error('unauthorized');
+    if (!res.ok) {
+      const err = new Error(data?.error || 'api_error');
+      err.status = res.status;
+      throw err;
+    }
+    return data;
+  }
+
+  async function publicJson(path, { method = 'GET', body = null } = {}) {
+    const opts = { method };
+    if (body !== null) {
+      opts.headers = { 'Content-Type': 'application/json' };
+      opts.body = JSON.stringify(body);
+    }
+    let res;
+    try {
+      res = await fetch(state.API + path, opts);
+    } catch (err) {
+      if (err instanceof TypeError) throw new Error('network_error');
+      throw err;
+    }
+    let data = {};
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) data = await res.json();
+    if (!res.ok) {
+      const err = new Error(data?.error || 'api_error');
+      err.status = res.status;
+      throw err;
+    }
+    return data;
+  }
+
+  async function loadUsers() {
+    if (!state.currentUser || state.currentUser.role !== 'admin') return;
+    hideNotice(userFeedback);
+    try {
+      const list = await api('/api/users');
+      userList.innerHTML = '';
+      for (const user of list) {
+        const li = document.createElement('li');
+        const left = document.createElement('div');
+        const strong = document.createElement('strong');
+        strong.textContent = user.username;
+        left.appendChild(strong);
+        const meta = document.createElement('div');
+        meta.className = 'muted small';
+        meta.textContent = `Role: ${user.role}`;
+        left.appendChild(meta);
+        const right = document.createElement('div');
+        right.className = 'server-actions';
+        if (user.id === state.currentUser.id) {
+          const badge = document.createElement('span');
+          badge.className = 'badge';
+          badge.textContent = 'You';
+          right.appendChild(badge);
+        } else {
+          const roleBtn = document.createElement('button');
+          roleBtn.className = 'ghost small';
+          roleBtn.textContent = user.role === 'admin' ? 'Make user' : 'Promote to admin';
+          roleBtn.onclick = async () => {
+            try {
+              await api(`/api/users/${user.id}`, { role: user.role === 'admin' ? 'user' : 'admin' }, 'PATCH');
+              showNotice(userFeedback, 'Updated role for ' + user.username, 'success');
+              loadUsers();
+            } catch (err) {
+              if (errorCode(err) === 'unauthorized') handleUnauthorized();
+              else showNotice(userFeedback, describeError(err), 'error');
+            }
+          };
+          const resetBtn = document.createElement('button');
+          resetBtn.className = 'ghost small';
+          resetBtn.textContent = 'Reset password';
+          resetBtn.onclick = async () => {
+            const newPass = prompt(`Enter a new password for ${user.username} (min 8 chars):`);
+            if (!newPass) return;
+            if (newPass.length < 8) {
+              showNotice(userFeedback, 'Password must be at least 8 characters.', 'error');
+              return;
+            }
+            try {
+              await api(`/api/users/${user.id}/password`, { newPassword: newPass }, 'POST');
+              showNotice(userFeedback, 'Password updated for ' + user.username, 'success');
+            } catch (err) {
+              if (errorCode(err) === 'unauthorized') handleUnauthorized();
+              else showNotice(userFeedback, describeError(err), 'error');
+            }
+          };
+          const deleteBtn = document.createElement('button');
+          deleteBtn.className = 'ghost small';
+          deleteBtn.textContent = 'Remove';
+          deleteBtn.onclick = async () => {
+            if (!confirm(`Remove ${user.username}? This cannot be undone.`)) return;
+            try {
+              await api(`/api/users/${user.id}`, null, 'DELETE');
+              showNotice(userFeedback, 'Removed ' + user.username, 'success');
+              loadUsers();
+            } catch (err) {
+              if (errorCode(err) === 'unauthorized') handleUnauthorized();
+              else showNotice(userFeedback, describeError(err), 'error');
+            }
+          };
+          right.appendChild(roleBtn);
+          right.appendChild(resetBtn);
+          right.appendChild(deleteBtn);
+        }
+        li.appendChild(left);
+        li.appendChild(right);
+        userList.appendChild(li);
+      }
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else showNotice(userFeedback, describeError(err), 'error');
+    }
+  }
+
+  function toggleUserCard() {
+    if (state.currentUser?.role === 'admin') {
+      userCard.classList.remove('hidden');
+      loadUsers();
+    } else {
+      userCard.classList.add('hidden');
+      userList.innerHTML = '';
+    }
+  }
+
+  async function attemptSessionResume() {
+    if (!state.TOKEN) {
+      ui.showLogin();
+      return;
+    }
+    try {
+      const me = await api('/api/me');
+      state.currentUser = me;
+      ui.setUser(me);
+      ui.showApp();
+      ensureSocket();
+      await refreshServers();
+      await loadPlayers();
+      toggleUserCard();
+      startStatusPolling();
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') {
+        logout();
+      } else {
+        ui.log('Session restore failed: ' + describeError(err));
+        logout();
+      }
+    }
+  }
+
+  async function handleLogin() {
+    hideNotice(loginError);
+    const base = apiBaseInput?.value;
+    if (base) setApiBase(base);
+    const username = loginUsername?.value.trim();
+    const password = loginPassword?.value || '';
+    if (!username || !password) {
+      showNotice(loginError, describeError('missing_fields'), 'error');
+      return;
+    }
+    try {
+      const data = await publicJson('/api/login', { method: 'POST', body: { username, password } });
+      state.TOKEN = data.token;
+      localStorage.setItem('token', state.TOKEN);
+      state.currentUser = { id: data.id, username: data.username, role: data.role };
+      ui.setUser(state.currentUser);
+      ui.showApp();
+      ensureSocket();
+      await refreshServers();
+      await loadPlayers();
+      toggleUserCard();
+      startStatusPolling();
+    } catch (err) {
+      showNotice(loginError, describeError(err), 'error');
+    }
+  }
+
+  async function handleRegister() {
+    hideNotice(registerError);
+    hideNotice(registerSuccess);
+    if (!state.allowRegistration) {
+      showNotice(registerError, describeError('registration_disabled'), 'error');
+      return;
+    }
+    const username = regUsername?.value.trim();
+    const password = regPassword?.value || '';
+    const confirm = regConfirm?.value || '';
+    if (!username || !password || !confirm) {
+      showNotice(registerError, describeError('missing_fields'), 'error');
+      return;
+    }
+    if (password !== confirm) {
+      showNotice(registerError, 'Passwords do not match.', 'error');
+      return;
+    }
+    try {
+      await publicJson('/api/register', { method: 'POST', body: { username, password } });
+      showNotice(registerSuccess, 'Account created. You can now sign in.', 'success');
+      if (loginUsername) loginUsername.value = username;
+      if (loginPassword) loginPassword.value = '';
+      if (regPassword) regPassword.value = '';
+      if (regConfirm) regConfirm.value = '';
+    } catch (err) {
+      showNotice(registerError, describeError(err), 'error');
+    }
+  }
+
+  async function addServer() {
+    const name = svName?.value.trim();
+    const host = svHost?.value.trim();
+    const port = parseInt(svPort?.value || '0', 10);
+    const password = svPass?.value.trim();
+    const useTls = !!svTLS?.checked;
+    if (!name || !host || !port || !password) {
+      ui.log('Please fill in all server fields before adding.');
+      return;
+    }
+    try {
+      await api('/api/servers', { name, host, port, password, tls: useTls }, 'POST');
+      ui.log('Server added: ' + name);
+      if (svName) svName.value = '';
+      if (svHost) svHost.value = '';
+      if (svPort) svPort.value = '28017';
+      if (svPass) svPass.value = '';
+      if (svTLS) svTLS.checked = false;
+      await refreshServers();
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else ui.log('Failed to add server: ' + describeError(err));
+    }
+  }
+
+  async function sendCommand() {
+    const cmd = cmdInput?.value.trim();
+    if (!cmd) return;
+    if (state.currentServerId == null) {
+      ui.log('Select a server before sending commands.');
+      return;
+    }
+    try {
+      const reply = await api(`/api/rcon/${state.currentServerId}`, { cmd }, 'POST');
+      ui.log('> ' + cmd);
+      if (reply?.Message) ui.log(reply.Message.trim());
+      cmdInput.value = '';
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else ui.log('Command failed: ' + describeError(err));
+    }
+  }
+
+  async function syncFromSteam() {
     const raw = prompt('Enter comma-separated Steam64 IDs to sync:');
     if (!raw) return;
-    const steamids = raw.split(',').map(s=>s.trim()).filter(Boolean);
+    const steamids = raw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (steamids.length === 0) return;
     try {
       const res = await api('/api/steam/sync', { steamids }, 'POST');
       ui.log('Synced ' + res.updated + ' players from Steam');
       await loadPlayers();
-    } catch (e) { alert('Sync failed: ' + e.message); }
-  };
-  (() => { const card = playersEl.closest('.card'); if (card) { const h3 = card.querySelector('h3'); const span = document.createElement('span'); span.style.float='right'; span.appendChild(syncBtn); h3.appendChild(span); } })();
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else ui.log('Sync failed: ' + describeError(err));
+    }
+  }
 
-  if (TOKEN) {
-    ui.setUser('…');
-    ui.showApp();
-    try { await refreshServers(); } catch { ui.showLogin(); }
-  } else { ui.showLogin(); }
+  function setupQuickButtons() {
+    document.querySelectorAll('[data-quick]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        if (!cmdInput) return;
+        cmdInput.value = btn.getAttribute('data-quick') || '';
+        cmdInput.focus();
+      });
+    });
+  }
+
+  function bindEvents() {
+    $('#btnLogin')?.addEventListener('click', handleLogin);
+    btnRegister?.addEventListener('click', handleRegister);
+    btnAddServer?.addEventListener('click', addServer);
+    btnSend?.addEventListener('click', sendCommand);
+    cmdInput?.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        sendCommand();
+      }
+    });
+    btnRefreshServers?.addEventListener('click', () => refreshServers());
+    btnClearConsole?.addEventListener('click', () => ui.clearConsole());
+    btnSyncPlayers?.addEventListener('click', syncFromSteam);
+    btnCreateUser?.addEventListener('click', async () => {
+      if (state.currentUser?.role !== 'admin') return;
+      hideNotice(userFeedback);
+      const username = newUserName?.value.trim();
+      const password = newUserPassword?.value || '';
+      const role = newUserRole?.value || 'user';
+      if (!username || !password) {
+        showNotice(userFeedback, describeError('missing_fields'), 'error');
+        return;
+      }
+      if (password.length < 8) {
+        showNotice(userFeedback, describeError('weak_password'), 'error');
+        return;
+      }
+      try {
+        await api('/api/users', { username, password, role }, 'POST');
+        showNotice(userFeedback, 'Created user ' + username, 'success');
+        if (newUserName) newUserName.value = '';
+        if (newUserPassword) newUserPassword.value = '';
+        if (newUserRole) newUserRole.value = 'user';
+        loadUsers();
+      } catch (err) {
+        if (errorCode(err) === 'unauthorized') handleUnauthorized();
+        else showNotice(userFeedback, describeError(err), 'error');
+      }
+    });
+    apiBaseInput?.addEventListener('change', (e) => setApiBase(e.target.value));
+    apiBaseInput?.addEventListener('blur', (e) => setApiBase(e.target.value));
+  }
+
+  async function init() {
+    const storedBase = localStorage.getItem('apiBase') || apiBaseInput?.value || 'http://localhost:8787';
+    setApiBase(storedBase || 'http://localhost:8787');
+    bindEvents();
+    setupQuickButtons();
+    if (state.TOKEN) {
+      await attemptSessionResume();
+    } else {
+      ui.showLogin();
+    }
+  }
+
+  init();
 })();

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1,27 +1,92 @@
 :root{
-  --bg:#0b0f14; --card:#111827; --muted:#8ca3b0; --accent:#00e676; --text:#dbe8ef;
+  --bg:#04070d;
+  --bg-alt:#0b101a;
+  --card:#111a2a;
+  --card-border:#1c2a3d;
+  --muted:#8ca3b0;
+  --text:#dbe8ef;
+  --accent:#5eead4;
+  --accent-strong:#2dd4bf;
+  --danger:#f87171;
+  --success:#4ade80;
 }
-*{box-sizing:border-box}
-body{margin:0;background:linear-gradient(180deg,#070a0f,#0b0f14);color:var(--text);font:16px/1.5 system-ui,Segoe UI,Roboto,Ubuntu}
-.wrap{max-width:1100px;margin:0 auto;padding:24px}
-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}
-h1{font-size:22px;margin:0}
-h2,h3{margin-top:0}
-.muted{color:var(--muted)}
+*{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Ubuntu,sans-serif}
+body{margin:0;min-height:100vh;background:radial-gradient(circle at 20% 20%,rgba(45,212,191,.12),transparent 40%),radial-gradient(circle at 80% 0,rgba(14,165,233,.08),transparent 45%),linear-gradient(180deg,#020409,#060a11);color:var(--text)}
+.wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px}
+.topbar{display:flex;justify-content:space-between;align-items:center;margin-bottom:32px;gap:16px}
+h1{margin:0;font-size:26px;font-weight:600}
+h2{margin-top:0;font-size:24px;font-weight:600}
+h3{margin:0;font-size:20px;font-weight:600}
+h4{margin:24px 0 8px;font-size:16px;font-weight:600}
 .small{font-size:12px}
-.card{background:var(--card);border:1px solid #1f2937;border-radius:16px;padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.25);margin-bottom:16px}
-.hidden{display:none}
-.grid2{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-.grid3{display:grid;grid-template-columns:280px 1fr 320px;gap:16px}
-.row{display:flex;gap:8px;margin-top:8px}
-input,button{padding:10px 12px;border-radius:12px;border:1px solid #2b3645;background:#0e1620;color:var(--text)}
-button{background:#0f172a;border-color:#243244;cursor:pointer}
-button:hover{border-color:#36506b}
-label{display:block;margin:.5rem 0}
-pre{background:#0a0e14;border:1px solid #1b2430;border-radius:12px;min-height:260px;max-height:420px;overflow:auto;padding:12px;white-space:pre-wrap}
+.muted{color:var(--muted)}
+.hidden{display:none!important}
+
+.auth-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:24px;margin-bottom:40px}
+.auth-card{background:var(--card);border:1px solid var(--card-border);border-radius:20px;padding:24px;box-shadow:0 18px 40px rgba(0,0,0,.25);backdrop-filter:blur(4px)}
+.auth-card label{display:flex;flex-direction:column;gap:6px;margin:14px 0 0;font-size:14px;color:var(--muted)}
+.auth-card input{padding:12px 14px;border-radius:14px;border:1px solid #1f2b3d;background:var(--bg-alt);color:var(--text)}
+.auth-card button{margin-top:18px;width:100%}
+
+.card{background:var(--card);border:1px solid var(--card-border);border-radius:20px;padding:18px;box-shadow:0 20px 40px rgba(0,0,0,.18);margin-bottom:20px}
+.card-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px}
+.card-header h3{font-size:18px}
+
+input,button,select{font-size:15px}
+input,select{padding:10px 12px;border-radius:12px;border:1px solid #1f2b3d;background:var(--bg-alt);color:var(--text)}
+select{appearance:none;background-image:url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" fill="none"%3E%3Cpath d="M1 1.5L6 6.5L11 1.5" stroke="%23dbe8ef" stroke-width="1.4" stroke-linecap="round"/%3E%3C/svg%3E');background-repeat:no-repeat;background-position:right 12px center;padding-right:34px}
+button{padding:10px 14px;border-radius:12px;border:1px solid #27384d;background:#0f172a;color:var(--text);cursor:pointer;transition:all .2s ease}
+button:hover{border-color:#3a5676}
+button.accent{background:var(--accent);border-color:var(--accent-strong);color:#04121a;font-weight:600}
+button.accent:hover{filter:brightness(1.05)}
+button.ghost{background:transparent;border-color:#243244}
+button.ghost:hover{border-color:#31506d}
+button.icon{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:50%;background:transparent;border:1px solid #243244}
+button.icon:hover{border-color:var(--accent-strong);color:var(--accent)}
+button.small{padding:6px 10px;font-size:13px;border-radius:10px}
+
+.row{display:flex;gap:10px;align-items:center;margin-top:12px}
+.row.quick-row{flex-wrap:wrap}
+.inline{display:flex;align-items:center;gap:10px;margin-top:14px;font-size:14px;color:var(--muted)}
+.grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.grid2.stack-sm{grid-template-columns:1fr}
+.grid3{display:grid;grid-template-columns:320px minmax(0,1fr) 320px;gap:20px;align-items:start}
+@media(max-width:1100px){.grid3{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}}
+
+pre{background:#070b13;border:1px solid #182233;border-radius:16px;min-height:260px;max-height:420px;overflow:auto;padding:14px;font-family:"JetBrains Mono",monospace;font-size:13px}
+
 ul{list-style:none;padding:0;margin:0}
-ul li{display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid #1c2633;padding:8px 0}
-ul li:last-child{border-bottom:none}
-details{margin-top:10px}
-summary{cursor:pointer}
-.badge{background:#0f2230;border:1px solid #1e3347;border-radius:999px;padding:2px 8px;font-size:12px;color:var(--accent)}
+#servers li{border:1px solid rgba(255,255,255,0.04);border-radius:14px;padding:12px;margin-bottom:10px;background:#0b131f;display:flex;flex-direction:column;gap:8px;transition:border-color .2s ease,box-shadow .2s ease}
+#servers li.active{border-color:rgba(94,234,212,0.45);box-shadow:0 0 0 1px rgba(94,234,212,0.35)}
+#servers li .server-heading{display:flex;justify-content:space-between;align-items:center;gap:10px}
+.status-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;font-size:12px;font-weight:600;border:1px solid rgba(255,255,255,0.1);background:rgba(148,163,184,0.12);color:var(--muted)}
+.status-pill.online{background:rgba(94,234,212,0.12);border-color:rgba(94,234,212,0.35);color:var(--accent)}
+.status-pill.offline{background:rgba(248,113,113,0.12);border-color:rgba(248,113,113,0.35);color:var(--danger)}
+.status-pill.degraded{background:rgba(250,204,21,0.12);border-color:rgba(250,204,21,0.35);color:#facc15}
+.server-meta{display:flex;flex-wrap:wrap;gap:10px;font-size:13px;color:var(--muted)}
+.server-actions{display:flex;gap:8px;align-items:center}
+
+#players li,#userList li{display:flex;justify-content:space-between;align-items:flex-start;border-bottom:1px solid rgba(255,255,255,0.06);padding:10px 0;gap:12px}
+#players li:last-child,#userList li:last-child{border-bottom:none}
+#players li strong{display:block;font-size:15px}
+.badge{background:#102233;border:1px solid #1e3347;border-radius:999px;padding:3px 8px;font-size:11px;color:var(--accent);text-transform:uppercase;letter-spacing:.05em}
+
+.notice{margin-top:12px;padding:10px 12px;border-radius:12px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.08);font-size:14px;color:var(--muted)}
+.notice.success{background:rgba(74,222,128,0.12);border-color:rgba(74,222,128,0.35);color:var(--success)}
+.notice.error{background:rgba(248,113,113,0.12);border-color:rgba(248,113,113,0.35);color:var(--danger)}
+
+.user-create label{display:flex;flex-direction:column;gap:6px;margin-top:16px;font-size:14px;color:var(--muted)}
+.user-create .row{justify-content:flex-start}
+#userBox{display:flex;align-items:center;gap:12px}
+#userBox button{padding:6px 12px;font-size:13px;border-radius:10px;background:transparent;border:1px solid #243244;color:var(--muted)}
+#userBox button:hover{border-color:var(--accent-strong);color:var(--accent)}
+
+#servers button.connect{align-self:flex-start}
+#servers .status-details{font-size:12px;color:var(--muted)}
+
+@media(max-width:720px){
+  .wrap{padding:24px 16px 48px}
+  .auth-card{padding:20px}
+  .card{padding:16px}
+  .grid3{grid-template-columns:1fr}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,26 +8,43 @@
 </head>
 <body>
   <div class="wrap">
-    <header>
+    <header class="topbar">
       <h1>Rust Admin Online — Open Source</h1>
       <div id="userBox" class="muted"></div>
     </header>
 
-    <section id="loginPanel" class="card">
-      <h2>Login</h2>
-      <label>API Base (e.g. http://localhost:8787)<input id="apiBase" value="http://localhost:8787"></label>
-      <div class="grid2">
-        <label>Username<input id="username" value="admin"></label>
-        <label>Password<input id="password" type="password" value="admin123"></label>
+    <section id="loginPanel" class="auth-grid">
+      <div class="auth-card">
+        <h2>Welcome back</h2>
+        <p class="muted">Sign in to orchestrate your Rust worlds and keep every server in check.</p>
+        <label>API Base URL<input id="apiBase" value="http://localhost:8787" placeholder="http://localhost:8787"></label>
+        <label>Username<input id="username" value="admin" autocomplete="username"></label>
+        <label>Password<input id="password" type="password" value="admin123" autocomplete="current-password"></label>
+        <button id="btnLogin" class="accent">Sign in</button>
+        <p id="loginError" class="notice hidden"></p>
+        <p class="muted small">Default credentials are for first boot only — change them in Settings once you are inside.</p>
       </div>
-      <button id="btnLogin">Sign in</button>
-      <p class="muted small">Default creds are for first boot only — change them in Settings.</p>
+      <div class="auth-card" id="registerCard">
+        <h2>Create an account</h2>
+        <p id="registerInfo" class="muted">Registration is disabled by the administrator.</p>
+        <div id="registerForm" class="hidden">
+          <label>Username<input id="regUsername" autocomplete="username" placeholder="yourname"></label>
+          <label>Password<input id="regPassword" type="password" autocomplete="new-password" placeholder="Minimum 8 characters"></label>
+          <label>Confirm password<input id="regConfirm" type="password" autocomplete="new-password"></label>
+          <button id="btnRegister" class="ghost">Register</button>
+          <p id="registerError" class="notice hidden"></p>
+          <p id="registerSuccess" class="notice success hidden"></p>
+        </div>
+      </div>
     </section>
 
     <section id="appPanel" class="hidden">
-      <div class="grid3">
-        <div class="card">
-          <h3>Servers</h3>
+      <div class="grid3" id="mainGrid">
+        <div class="card" id="serversCard">
+          <div class="card-header">
+            <h3>Servers</h3>
+            <button id="btnRefreshServers" class="icon" title="Refresh">⟳</button>
+          </div>
           <ul id="servers"></ul>
           <details>
             <summary>Add server</summary>
@@ -37,30 +54,61 @@
               <input id="svPort" type="number" placeholder="RCON Port" value="28017">
               <input id="svPass" placeholder="Password">
             </div>
-            <label><input type="checkbox" id="svTLS"> TLS (wss)</label>
-            <button id="btnAddServer">Add</button>
+            <label class="inline"><input type="checkbox" id="svTLS"> Use TLS (wss)</label>
+            <button id="btnAddServer" class="ghost">Add server</button>
           </details>
         </div>
 
         <div class="card">
-          <h3>Console</h3>
+          <div class="card-header">
+            <h3>Console</h3>
+            <button id="btnClearConsole" class="icon" title="Clear console">✕</button>
+          </div>
           <pre id="console"></pre>
           <div class="row">
             <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
-            <button id="btnSend">Send</button>
+            <button id="btnSend" class="accent">Send</button>
           </div>
-          <div class="row">
-            <button data-quick="status">status</button>
-            <button data-quick="serverinfo">serverinfo</button>
-            <button data-quick='say "Hello from panel"'>say</button>
-            <button data-quick="playerlist">playerlist</button>
+          <div class="row quick-row">
+            <button data-quick="status" class="ghost">status</button>
+            <button data-quick="serverinfo" class="ghost">serverinfo</button>
+            <button data-quick='say "Hello from panel"' class="ghost">say</button>
+            <button data-quick="playerlist" class="ghost">playerlist</button>
           </div>
         </div>
 
         <div class="card">
-          <h3>Players</h3>
+          <div class="card-header">
+            <h3>Players</h3>
+            <button id="btnSyncPlayers" class="ghost small">Sync from Steam</button>
+          </div>
           <ul id="players"></ul>
         </div>
+      </div>
+
+      <div id="userCard" class="card hidden">
+        <div class="card-header">
+          <h3>Team access</h3>
+        </div>
+        <div class="user-create">
+          <h4>Invite a teammate</h4>
+          <div class="grid2 stack-sm">
+            <input id="newUserName" placeholder="Username">
+            <input id="newUserPassword" type="password" placeholder="Temporary password">
+          </div>
+          <label>Role
+            <select id="newUserRole">
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+          <div class="row">
+            <button id="btnCreateUser" class="accent">Create user</button>
+          </div>
+          <p id="userFeedback" class="notice hidden"></p>
+        </div>
+        <h4>Existing users</h4>
+        <ul id="userList" class="users"></ul>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- add background server monitoring with status reporting endpoints and configurable poll interval
- extend authentication and data layer with user roles, admin management APIs, and optional self-registration
- refresh the frontend with a new login/register experience, server health indicators, and team access controls

## Testing
- node backend/src/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d1c42bdda08331b2fe9f0277105fc9