### PR TITLE
Add modular dashboard with live map integration

### DIFF
--- a/README-linux.md
+++ b/README-linux.md
@@ -44,6 +44,7 @@ MYSQL_DATABASE=rustadmin
 ```
 
 Set `STEAM_API_KEY=...` for Steam enrichment.
+Set `RUSTMAPS_API_KEY=...` to enable the live map module (see https://api.rustmaps.com for keys).
 
 ## Access control
 

--- a/README-linux.md
+++ b/README-linux.md
@@ -44,7 +44,7 @@ MYSQL_DATABASE=rustadmin
 ```
 
 Set `STEAM_API_KEY=...` for Steam enrichment.
-Set `RUSTMAPS_API_KEY=...` to enable the live map module (see https://api.rustmaps.com for keys).
+Set `RUSTMAPS_API_KEY=...` to provide a fallback RustMaps key (optional). Each panel user can store their own key from **Settings → Personal settings** — required for the live map module (see https://api.rustmaps.com for keys).
 
 ## Access control
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,9 +4,17 @@ import cors from 'cors';
 import http from 'http';
 import { Server as IOServer } from 'socket.io';
 import bcrypt from 'bcrypt';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { db, initDb } from './db/index.js';
 import { authMiddleware, signToken, requireAdmin } from './auth.js';
 import { RustWebRcon } from './rcon.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_DIR = process.env.DATA_DIR ? path.resolve(process.env.DATA_DIR) : path.resolve(process.cwd(), 'data');
+const MAP_STORAGE_DIR = path.join(DATA_DIR, 'maps');
 
 const app = express();
 const server = http.createServer(app);
@@ -23,20 +31,22 @@ const toInt = (value, fallback) => {
 };
 
 const MONITOR_INTERVAL = Math.max(toInt(process.env.MONITOR_INTERVAL_MS || '60000', 60000), 15000);
-const RUSTMAPS_API_KEY = process.env.RUSTMAPS_API_KEY || '';
+const DEFAULT_RUSTMAPS_API_KEY = process.env.RUSTMAPS_API_KEY || '';
 const SERVER_INFO_TTL = Math.max(toInt(process.env.SERVER_INFO_CACHE_MS, 60000), 10000);
-const MAP_CACHE_TTL = Math.max(toInt(process.env.RUSTMAPS_CACHE_MS, 30 * 60 * 1000), 60000);
+const ALLOWED_USER_SETTINGS = new Set(['rustmaps_api_key']);
+const MAP_PURGE_INTERVAL = Math.max(toInt(process.env.MAP_PURGE_INTERVAL_MS, 6 * 60 * 60 * 1000), 15 * 60 * 1000);
 
-app.use(express.json({ limit: '1mb' }));
+app.use(express.json({ limit: '25mb' }));
 app.use(cors({ origin: (origin, cb) => cb(null, true), credentials: true }));
 
 await initDb();
+await fs.mkdir(MAP_STORAGE_DIR, { recursive: true });
+await purgeExpiredMapCaches().catch((err) => console.error('initial map purge failed', err));
 
 const auth = authMiddleware(JWT_SECRET);
 const rconMap = new Map();
 const statusMap = new Map();
 const serverInfoCache = new Map();
-const mapCache = new Map();
 let monitoring = false;
 let monitorTimer = null;
 
@@ -187,18 +197,128 @@ function cacheServerInfo(id, info) {
   serverInfoCache.set(id, { data: info, timestamp: Date.now() });
 }
 
-async function fetchRustMapMetadata(size, seed) {
+function firstThursdayOfMonth(date = new Date()) {
+  const first = new Date(date.getFullYear(), date.getMonth(), 1);
+  const offset = (4 - first.getDay() + 7) % 7;
+  first.setDate(first.getDate() + offset);
+  first.setHours(0, 0, 0, 0);
+  return first;
+}
+
+function parseTimestamp(value) {
+  if (!value) return null;
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) return null;
+  return new Date(ts);
+}
+
+function shouldResetMapRecord(record, now = new Date()) {
+  if (!record) return false;
+  const updated = parseTimestamp(record.updated_at || record.updatedAt || record.created_at || record.createdAt);
+  if (!updated) return false;
+  const first = firstThursdayOfMonth(now);
+  return now >= first && updated < first;
+}
+
+function sanitizeFilenameSegment(value) {
+  return (String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'map').slice(0, 80);
+}
+
+function mapImageFilePath(serverId, mapKey, extension = 'png') {
+  const safeKey = sanitizeFilenameSegment(mapKey || `server-${serverId}`);
+  return path.join(MAP_STORAGE_DIR, `server-${serverId}-${safeKey}.${extension}`);
+}
+
+function isWithinDir(targetPath, dir) {
+  if (!targetPath) return false;
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedDir = path.resolve(dir);
+  return resolvedTarget.startsWith(resolvedDir);
+}
+
+async function removeMapImage(record) {
+  if (!record?.image_path) return;
+  if (!isWithinDir(record.image_path, MAP_STORAGE_DIR)) return;
+  try {
+    await fs.unlink(record.image_path);
+  } catch (err) {
+    if (err?.code !== 'ENOENT') console.warn('Failed to remove cached map image', err);
+  }
+}
+
+async function purgeExpiredMapCaches(now = new Date()) {
+  if (typeof db.listServerMaps !== 'function') return;
+  let rows;
+  try {
+    rows = await db.listServerMaps();
+  } catch (err) {
+    console.error('map cache query failed', err);
+    return;
+  }
+  if (!Array.isArray(rows) || rows.length === 0) return;
+  for (const row of rows) {
+    try {
+      if (!shouldResetMapRecord(row, now)) continue;
+      await removeMapImage(row);
+      const id = Number(row.server_id ?? row.serverId ?? row.id);
+      if (!Number.isFinite(id)) continue;
+      await db.deleteServerMap(id);
+    } catch (err) {
+      console.warn('map cache purge failed for server', row?.server_id ?? row?.serverId ?? row?.id, err);
+    }
+  }
+}
+
+function mapRecordToPayload(serverId, record) {
+  if (!record) return null;
+  let meta = {};
+  if (record.data) {
+    try { meta = JSON.parse(record.data); } catch { /* ignore parse errors */ }
+  }
+  const updatedAt = record.updated_at || record.updatedAt || record.created_at || record.createdAt || null;
+  const payload = {
+    ...meta,
+    mapKey: record.map_key || meta.mapKey || null,
+    cached: true,
+    cachedAt: updatedAt,
+    custom: !!record.custom
+  };
+  if (record.image_path) {
+    payload.imageUrl = `/api/servers/${serverId}/map-image?v=${encodeURIComponent(updatedAt || '')}`;
+    payload.localImage = true;
+  } else if (!payload.imageUrl) {
+    payload.imageUrl = null;
+  }
+  if (payload.custom && !payload.imageUrl) payload.needsUpload = true;
+  return payload;
+}
+
+function deriveMapKey(info = {}, metadata = null) {
+  const rawSize = Number(metadata?.size ?? info.size);
+  const rawSeed = Number(metadata?.seed ?? info.seed);
+  const saveVersion = metadata?.saveVersion || null;
+  const parts = [];
+  if (Number.isFinite(rawSize)) parts.push(`size${rawSize}`);
+  if (Number.isFinite(rawSeed)) parts.push(`seed${rawSeed}`);
+  if (saveVersion) parts.push(`v${saveVersion}`);
+  if (!parts.length && info.mapName) parts.push(`name-${info.mapName}`);
+  if (!parts.length && metadata?.id) parts.push(`id${metadata.id}`);
+  return parts.length ? parts.join(':') : null;
+}
+
+async function fetchRustMapMetadata(size, seed, apiKey) {
   if (!size || !seed) return null;
-  const key = `${size}:${seed}`;
-  const cached = mapCache.get(key);
-  if (cached && Date.now() - cached.timestamp < MAP_CACHE_TTL) return cached.data;
-  if (!RUSTMAPS_API_KEY) {
-    const err = new Error('no_rustmaps_api_key');
-    err.code = 'no_rustmaps_api_key';
+  if (!apiKey) {
+    const err = new Error('rustmaps_api_key_missing');
+    err.code = 'rustmaps_api_key_missing';
     throw err;
   }
   const url = `https://api.rustmaps.com/v4/maps/${encodeURIComponent(size)}/${encodeURIComponent(seed)}?staging=false`;
-  const res = await fetch(url, { headers: { 'x-api-key': RUSTMAPS_API_KEY } });
+  const res = await fetch(url, { headers: { 'x-api-key': apiKey } });
   if (res.status === 401 || res.status === 403) {
     const err = new Error('rustmaps_unauthorized');
     err.code = 'rustmaps_unauthorized';
@@ -222,12 +342,13 @@ async function fetchRustMapMetadata(size, seed) {
     err.code = 'rustmaps_error';
     throw err;
   }
-  const normalized = {
+  return {
     id: data.id || null,
     type: data.type || null,
-    seed: data.seed || seed,
-    size: data.size || size,
+    seed: Number(data.seed ?? seed) || seed,
+    size: Number(data.size ?? size) || size,
     saveVersion: data.saveVersion || null,
+    mapName: data.mapName || data.map || null,
     imageUrl: data.imageUrl || data.rawImageUrl || null,
     rawImageUrl: data.rawImageUrl || null,
     thumbnailUrl: data.thumbnailUrl || null,
@@ -235,8 +356,47 @@ async function fetchRustMapMetadata(size, seed) {
     isCustomMap: !!data.isCustomMap,
     totalMonuments: data.totalMonuments || null
   };
-  mapCache.set(key, { data: normalized, timestamp: Date.now() });
-  return normalized;
+}
+
+async function downloadRustMapImage(meta, apiKey) {
+  const imageUrl = meta?.imageUrl || meta?.rawImageUrl;
+  if (!imageUrl) return null;
+  const headers = apiKey ? { 'x-api-key': apiKey } : undefined;
+  const res = await fetch(imageUrl, { headers });
+  if (!res.ok) {
+    const err = new Error('rustmaps_image_error');
+    err.code = 'rustmaps_image_error';
+    err.status = res.status;
+    throw err;
+  }
+  const arrayBuffer = await res.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const type = res.headers.get('content-type') || '';
+  let extension = 'jpg';
+  if (type.includes('png')) extension = 'png';
+  else if (type.includes('webp')) extension = 'webp';
+  return { buffer, extension, mime: type || 'image/jpeg' };
+}
+
+function decodeBase64Image(input) {
+  if (typeof input !== 'string' || !input) return null;
+  let data = input.trim();
+  let mime = 'application/octet-stream';
+  const match = data.match(/^data:(.+);base64,(.*)$/);
+  if (match) {
+    mime = match[1];
+    data = match[2];
+  }
+  try {
+    const buffer = Buffer.from(data, 'base64');
+    let extension = 'jpg';
+    if (mime.includes('png')) extension = 'png';
+    else if (mime.includes('webp')) extension = 'webp';
+    else if (mime.includes('jpeg')) extension = 'jpg';
+    return { buffer, mime, extension };
+  } catch {
+    return null;
+  }
 }
 
 async function monitorServers() {
@@ -292,6 +452,11 @@ const monitorHandle = setInterval(() => {
 if (monitorHandle.unref) monitorHandle.unref();
 monitorServers().catch((err) => console.error('initial monitor error', err));
 
+const mapPurgeHandle = setInterval(() => {
+  purgeExpiredMapCaches().catch((err) => console.error('scheduled map purge error', err));
+}, MAP_PURGE_INTERVAL);
+if (mapPurgeHandle.unref) mapPurgeHandle.unref();
+
 // --- Public metadata
 app.get('/api/public-config', (req, res) => {
   res.json({ allowRegistration: ALLOW_REGISTRATION });
@@ -336,6 +501,36 @@ app.get('/api/me', auth, async (req, res) => {
     if (!row) return res.status(404).json({ error: 'not_found' });
     res.json({ id: row.id, username: row.username, role: row.role, created_at: row.created_at });
   } catch (e) {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.get('/api/me/settings', auth, async (req, res) => {
+  try {
+    const settings = await db.getUserSettings(req.user.uid);
+    res.json(settings);
+  } catch {
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/me/settings', auth, async (req, res) => {
+  const payload = req.body;
+  if (!payload || typeof payload !== 'object') return res.status(400).json({ error: 'invalid_payload' });
+  try {
+    for (const [key, value] of Object.entries(payload)) {
+      if (!ALLOWED_USER_SETTINGS.has(key)) continue;
+      const normalized = typeof value === 'string' ? value.trim() : value;
+      if (normalized === '' || normalized === null || typeof normalized === 'undefined') {
+        await db.deleteUserSetting(req.user.uid, key);
+      } else {
+        await db.setUserSetting(req.user.uid, key, String(normalized));
+      }
+    }
+    const settings = await db.getUserSettings(req.user.uid);
+    res.json(settings);
+  } catch (err) {
+    console.error('settings update failed', err);
     res.status(500).json({ error: 'db_error' });
   }
 });
@@ -505,27 +700,148 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       return res.status(502).json({ error: 'playerlist_failed' });
     }
     const players = parsePlayerListMessage(playerPayload);
-    let map = null;
-    if (info?.size && info?.seed) {
-      try {
-        map = await fetchRustMapMetadata(info.size, info.seed);
-      } catch (err) {
-        const code = err?.code || err?.message;
-        if (code === 'no_rustmaps_api_key' || code === 'rustmaps_unauthorized') {
-          return res.status(400).json({ error: code });
+    const now = new Date();
+    let mapRecord = await db.getServerMap(id);
+    if (mapRecord && shouldResetMapRecord(mapRecord, now)) {
+      await removeMapImage(mapRecord);
+      await db.deleteServerMap(id);
+      mapRecord = null;
+    }
+    const infoMapKey = deriveMapKey(info) || null;
+    if (mapRecord && !mapRecord.custom && infoMapKey && mapRecord.map_key && mapRecord.map_key !== infoMapKey) {
+      await removeMapImage(mapRecord);
+      await db.deleteServerMap(id);
+      mapRecord = null;
+    }
+    let map = mapRecordToPayload(id, mapRecord);
+    if (map && !map.mapKey && infoMapKey) map.mapKey = infoMapKey;
+    if (!map) {
+      if (info?.size && info?.seed) {
+        const userKey = await db.getUserSetting(req.user.uid, 'rustmaps_api_key');
+        const apiKey = userKey || DEFAULT_RUSTMAPS_API_KEY || '';
+        try {
+          let metadata = await fetchRustMapMetadata(info.size, info.seed, apiKey);
+          const finalKey = deriveMapKey(info, metadata) || infoMapKey;
+          const storedMeta = { ...metadata, mapKey: finalKey };
+          await removeMapImage(mapRecord);
+          let imagePath = null;
+          if (!metadata.isCustomMap) {
+            try {
+              const download = await downloadRustMapImage(metadata, apiKey);
+              if (download?.buffer) {
+                const filePath = mapImageFilePath(id, finalKey || infoMapKey || 'map', download.extension);
+                await fs.writeFile(filePath, download.buffer);
+                imagePath = filePath;
+              }
+            } catch (imageErr) {
+              console.warn('RustMaps image download failed', imageErr);
+            }
+          }
+          if (metadata.isCustomMap || imagePath) {
+            await db.saveServerMap(id, {
+              map_key: finalKey || infoMapKey,
+              data: JSON.stringify(storedMeta),
+              image_path: imagePath,
+              custom: metadata.isCustomMap ? 1 : 0
+            });
+            mapRecord = await db.getServerMap(id);
+            map = mapRecordToPayload(id, mapRecord);
+            if (map && !map.mapKey) map.mapKey = finalKey || infoMapKey;
+          } else {
+            map = { ...storedMeta, imageUrl: null, cached: false, custom: !!metadata.isCustomMap };
+          }
+        } catch (err) {
+          const code = err?.code || err?.message;
+          if (code === 'rustmaps_api_key_missing' || code === 'rustmaps_unauthorized') {
+            return res.status(400).json({ error: code });
+          }
+          if (code === 'rustmaps_not_found') {
+            map = {
+              mapKey: infoMapKey,
+              cached: false,
+              imageUrl: null,
+              custom: false,
+              notFound: true
+            };
+          } else if (code === 'rustmaps_image_error') {
+            console.warn('RustMaps image download error', err);
+            map = {
+              mapKey: infoMapKey,
+              cached: false,
+              imageUrl: null,
+              custom: false
+            };
+          } else {
+            console.error('RustMaps metadata fetch failed', err);
+            return res.status(502).json({ error: 'rustmaps_error' });
+          }
         }
-        if (code === 'rustmaps_not_found') {
-          map = null;
-        } else {
-          console.error('RustMaps metadata fetch failed', err);
-          return res.status(502).json({ error: 'rustmaps_error' });
-        }
+      } else if (mapRecord) {
+        map = mapRecordToPayload(id, mapRecord);
       }
     }
+    if (map && map.custom && !map.imageUrl) map.needsUpload = true;
+    if (map && !map.mapKey && infoMapKey) map.mapKey = infoMapKey;
+    if (map && typeof map.cached === 'undefined') map.cached = !!mapRecord;
     res.json({ players, map, info, fetchedAt: new Date().toISOString() });
   } catch (err) {
     console.error('live-map route error', err);
     res.status(500).json({ error: 'live_map_failed' });
+  }
+});
+
+app.post('/api/servers/:id/map-image', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const { image, mapKey } = req.body || {};
+  if (!image) return res.status(400).json({ error: 'missing_image' });
+  const decoded = decodeBase64Image(image);
+  if (!decoded?.buffer || decoded.buffer.length === 0) return res.status(400).json({ error: 'invalid_image' });
+  if (decoded.buffer.length > 20 * 1024 * 1024) return res.status(413).json({ error: 'image_too_large' });
+  try {
+    const server = await db.getServer(id);
+    if (!server) return res.status(404).json({ error: 'not_found' });
+    let record = await db.getServerMap(id);
+    const info = getCachedServerInfo(id) || {};
+    const derivedKey = deriveMapKey(info) || null;
+    const targetKey = mapKey || record?.map_key || derivedKey || `custom-${id}`;
+    if (record) await removeMapImage(record);
+    const filePath = mapImageFilePath(id, targetKey, decoded.extension);
+    await fs.writeFile(filePath, decoded.buffer);
+    let data = {};
+    if (record?.data) {
+      try { data = JSON.parse(record.data); } catch { data = {}; }
+    }
+    if (info?.size && !data.size) data.size = info.size;
+    if (info?.seed && !data.seed) data.seed = info.seed;
+    if (info?.mapName && !data.mapName) data.mapName = info.mapName;
+    data = { ...data, mapKey: targetKey, manualUpload: true };
+    await db.saveServerMap(id, {
+      map_key: targetKey,
+      data: JSON.stringify(data),
+      image_path: filePath,
+      custom: 1
+    });
+    record = await db.getServerMap(id);
+    const map = mapRecordToPayload(id, record);
+    res.json({ map, updatedAt: new Date().toISOString() });
+  } catch (err) {
+    console.error('map upload failed', err);
+    res.status(500).json({ error: 'map_upload_failed' });
+  }
+});
+
+app.get('/api/servers/:id/map-image', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  try {
+    const record = await db.getServerMap(id);
+    if (!record?.image_path) return res.status(404).json({ error: 'not_found' });
+    if (!isWithinDir(record.image_path, MAP_STORAGE_DIR)) return res.status(404).json({ error: 'not_found' });
+    await fs.stat(record.image_path);
+    res.sendFile(path.resolve(record.image_path));
+  } catch (err) {
+    res.status(404).json({ error: 'not_found' });
   }
 });
 

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -3,7 +3,7 @@
 
   const serversEl = $('#servers');
   const consoleEl = $('#console');
-  const playersEl = $('#players');
+  const moduleColumn = $('#moduleColumn');
   const loginPanel = $('#loginPanel');
   const appPanel = $('#appPanel');
   const userBox = $('#userBox');
@@ -16,7 +16,6 @@
   const userCard = $('#userCard');
   const userList = $('#userList');
   const userFeedback = $('#userFeedback');
-  const btnSyncPlayers = $('#btnSyncPlayers');
   const btnRefreshServers = $('#btnRefreshServers');
   const btnClearConsole = $('#btnClearConsole');
   const btnAddServer = $('#btnAddServer');
@@ -37,6 +36,7 @@
   const newUserPassword = $('#newUserPassword');
   const newUserRole = $('#newUserRole');
   const btnCreateUser = $('#btnCreateUser');
+  const quickCommandsEl = $('#quickCommands');
 
   const state = {
     API: '',
@@ -50,6 +50,119 @@
 
   let socket = null;
 
+  const moduleBus = (() => {
+    const listeners = new Map();
+    return {
+      on(event, handler) {
+        if (!event || typeof handler !== 'function') return () => {};
+        if (!listeners.has(event)) listeners.set(event, new Set());
+        const set = listeners.get(event);
+        set.add(handler);
+        return () => set.delete(handler);
+      },
+      emit(event, payload) {
+        const set = listeners.get(event);
+        if (!set) return;
+        for (const fn of [...set]) {
+          try { fn(payload); }
+          catch (err) { console.error('Module handler error for', event, err); }
+        }
+      }
+    };
+  })();
+
+  const quickCommands = new Map();
+
+  function setQuickInput(value) {
+    if (!cmdInput) return;
+    cmdInput.value = value || '';
+    cmdInput.focus();
+  }
+
+  function renderQuickCommands() {
+    if (!quickCommandsEl) return;
+    quickCommandsEl.innerHTML = '';
+    const items = [...quickCommands.values()].sort((a, b) => {
+      const orderA = typeof a.order === 'number' ? a.order : 100;
+      const orderB = typeof b.order === 'number' ? b.order : 100;
+      if (orderA !== orderB) return orderA - orderB;
+      return (a.label || '').localeCompare(b.label || '');
+    });
+    for (const item of items) {
+      const btn = document.createElement('button');
+      btn.className = item.className || 'ghost';
+      btn.textContent = item.label || item.command || item.id;
+      if (item.description) btn.title = item.description;
+      btn.addEventListener('click', () => {
+        if (typeof item.onClick === 'function') {
+          item.onClick({
+            setInput: setQuickInput,
+            run: runRconCommand,
+            command: item.command,
+            send: runRconCommand
+          });
+        } else if (item.command) {
+          setQuickInput(item.command);
+        }
+      });
+      quickCommandsEl.appendChild(btn);
+    }
+  }
+
+  function registerQuickCommand(definition) {
+    if (!definition) return () => {};
+    const id = definition.id || definition.command || `cmd-${quickCommands.size + 1}`;
+    const normalized = {
+      id,
+      label: definition.label || definition.command || id,
+      command: definition.command || '',
+      description: definition.description || '',
+      order: typeof definition.order === 'number' ? definition.order : 100,
+      className: definition.className || 'ghost',
+      onClick: typeof definition.onClick === 'function' ? definition.onClick : null
+    };
+    quickCommands.set(id, normalized);
+    renderQuickCommands();
+    return () => {
+      quickCommands.delete(id);
+      renderQuickCommands();
+    };
+  }
+
+  registerQuickCommand({ id: 'cmd-status', label: 'status', command: 'status', order: 10 });
+  registerQuickCommand({ id: 'cmd-serverinfo', label: 'serverinfo', command: 'serverinfo', order: 20 });
+  registerQuickCommand({ id: 'cmd-say', label: 'say', command: 'say "Hello from panel"', order: 30 });
+  registerQuickCommand({ id: 'cmd-playerlist', label: 'playerlist', command: 'playerlist', order: 40 });
+
+  function createModuleCard({ id, title, icon } = {}) {
+    if (!moduleColumn) throw new Error('Module mount element missing');
+    const card = document.createElement('div');
+    card.className = 'card module-card';
+    if (id) card.dataset.moduleId = id;
+    const header = document.createElement('div');
+    header.className = 'card-header';
+    const heading = document.createElement('h3');
+    heading.textContent = title || id || 'Module';
+    if (icon) heading.prepend(icon + ' ');
+    const actions = document.createElement('div');
+    actions.className = 'module-header-actions';
+    header.appendChild(heading);
+    header.appendChild(actions);
+    const body = document.createElement('div');
+    body.className = 'module-body';
+    card.appendChild(header);
+    card.appendChild(body);
+    moduleColumn.appendChild(card);
+    return {
+      card,
+      header,
+      body,
+      actions,
+      setTitle(value) { heading.textContent = value || ''; },
+      remove() { card.remove(); }
+    };
+  }
+
   const errorMessages = {
     invalid_login: 'Invalid username or password.',
     missing_fields: 'Please fill in all required fields.',
@@ -62,7 +175,15 @@
     network_error: 'Unable to reach the server. Check the API URL and your connection.',
     unauthorized: 'Your session expired. Please sign in again.',
     last_admin: 'You cannot remove the final administrator.',
-    cannot_delete_self: 'You cannot remove your own account.'
+    cannot_delete_self: 'You cannot remove your own account.',
+    no_rustmaps_api_key: 'RustMaps integration is not configured on the server.',
+    rustmaps_unauthorized: 'RustMaps rejected the configured API key.',
+    rustmaps_not_found: 'RustMaps could not find a generated map for this seed and size yet.',
+    rustmaps_error: 'RustMaps responded with an unexpected error.',
+    live_map_failed: 'Unable to load the live map right now.',
+    playerlist_failed: 'The server did not return a live player list.',
+    missing_command: 'Provide a command before sending.',
+    no_server_selected: 'Select a server before sending commands.'
   };
 
   function errorCode(err) {
@@ -160,7 +281,7 @@
     socket.on('console', (msg) => {
       if (msg?.Message) {
         ui.log(msg.Message.trim());
-        if (/SteamID|players connected|id :/.test(msg.Message)) rebuildPlayers(msg.Message);
+        moduleBus.emit('console:message', { serverId: state.currentServerId, message: msg });
       }
     });
     socket.on('error', (err) => {
@@ -242,6 +363,7 @@
       details.textContent = parts.join(' · ');
       details.title = status?.details?.raw || status?.error || '';
     }
+    moduleBus.emit('server:status', { serverId: Number(id), status });
   }
 
   function applyStatusMap(map) {
@@ -321,6 +443,7 @@
         renderServer(server, status);
       }
       highlightSelectedServer();
+      moduleBus.emit('servers:updated', { servers: list });
     } catch (err) {
       if (errorCode(err) === 'unauthorized') {
         handleUnauthorized();
@@ -348,58 +471,11 @@
     if (sock && sock.connected) {
       sock.emit('join-server', numericId);
     }
-    loadPlayers().catch(() => {});
-  }
-
-  function rebuildPlayers(text) {
-    playersEl.innerHTML = '';
-    const lines = (text || '').split(/\r?\n/).filter(Boolean);
-    for (const ln of lines) {
-      const li = document.createElement('li');
-      li.textContent = ln.trim();
-      playersEl.appendChild(li);
+    if (previous != null && previous !== numericId) {
+      moduleBus.emit('server:disconnected', { serverId: previous, reason: 'switch' });
     }
-  }
-
-  async function loadPlayers() {
-    try {
-      const list = await api('/api/players?limit=200');
-      playersEl.innerHTML = '';
-      for (const p of list) {
-        const li = document.createElement('li');
-        const left = document.createElement('div');
-        const name = document.createElement('strong');
-        name.textContent = p.persona || p.steamid;
-        left.appendChild(name);
-        const small = document.createElement('div');
-        small.className = 'muted small';
-        small.textContent = p.steamid;
-        left.appendChild(small);
-        const right = document.createElement('div');
-        right.className = 'server-actions';
-        if (p.country) {
-          const badge = document.createElement('span');
-          badge.className = 'badge';
-          badge.textContent = p.country;
-          right.appendChild(badge);
-        }
-        if (p.vac_banned) {
-          const badge = document.createElement('span');
-          badge.className = 'badge';
-          badge.textContent = 'VAC';
-          right.appendChild(badge);
-        }
-        li.appendChild(left);
-        li.appendChild(right);
-        playersEl.appendChild(li);
-      }
-    } catch (err) {
-      if (errorCode(err) === 'unauthorized') {
-        handleUnauthorized();
-      } else {
-        ui.log('Players load failed: ' + describeError(err));
-      }
-    }
+    moduleBus.emit('server:connected', { serverId: numericId, server: entry?.data || null });
+    moduleBus.emit('players:refresh', { reason: 'server-connect', serverId: numericId });
   }
 
   const ui = {
@@ -441,22 +517,60 @@
     }
   };
 
+  function getServerList() {
+    return [...state.serverItems.values()].map((entry) => entry.data).filter(Boolean);
+  }
+
+  function getServerData(id) {
+    return state.serverItems.get(String(id))?.data || null;
+  }
+
+  const moduleHostContext = {
+    createCard: createModuleCard,
+    on: moduleBus.on,
+    emit: moduleBus.emit,
+    api,
+    publicJson,
+    log: (line) => ui.log(line),
+    describeError,
+    errorCode,
+    handleUnauthorized,
+    registerQuickCommand,
+    setQuickInput,
+    sendCommand: runRconCommand,
+    runCommand: runRconCommand,
+    getState: () => ({
+      API: state.API,
+      currentUser: state.currentUser,
+      currentServerId: state.currentServerId,
+      servers: getServerList()
+    }),
+    getServers: getServerList,
+    getServer: getServerData
+  };
+
+  if (window.ModuleLoader?.init) {
+    window.ModuleLoader.init(moduleHostContext);
+  }
+
   function logout() {
+    const previousServer = state.currentServerId;
     state.TOKEN = '';
     state.currentUser = null;
-    state.currentServerId = null;
     stopStatusPolling();
     disconnectSocket();
     localStorage.removeItem('token');
     state.serverItems.clear();
     serversEl.innerHTML = '';
-    playersEl.innerHTML = '';
     ui.clearConsole();
     ui.setUser(null);
     userCard.classList.add('hidden');
     hideNotice(userFeedback);
     ui.showLogin();
     loadPublicConfig();
+    if (previousServer != null) moduleBus.emit('server:disconnected', { serverId: previousServer, reason: 'logout' });
+    state.currentServerId = null;
+    moduleBus.emit('auth:logout');
   }
 
   function handleUnauthorized() {
@@ -620,7 +734,8 @@
       ui.showApp();
       ensureSocket();
       await refreshServers();
-      await loadPlayers();
+      moduleBus.emit('auth:login', { user: state.currentUser, resume: true });
+      moduleBus.emit('players:refresh', { reason: 'session-resume' });
       toggleUserCard();
       startStatusPolling();
     } catch (err) {
@@ -652,7 +767,8 @@
       ui.showApp();
       ensureSocket();
       await refreshServers();
-      await loadPlayers();
+      moduleBus.emit('auth:login', { user: state.currentUser, resume: false });
+      moduleBus.emit('players:refresh', { reason: 'login' });
       toggleUserCard();
       startStatusPolling();
     } catch (err) {
@@ -715,6 +831,13 @@
     }
   }
 
+  async function runRconCommand(command) {
+    const cmd = (command || '').toString().trim();
+    if (!cmd) throw new Error('missing_command');
+    if (state.currentServerId == null) throw new Error('no_server_selected');
+    return await api(`/api/rcon/${state.currentServerId}`, { cmd }, 'POST');
+  }
+
   async function sendCommand() {
     const cmd = cmdInput?.value.trim();
     if (!cmd) return;
@@ -723,39 +846,18 @@
       return;
     }
     try {
-      const reply = await api(`/api/rcon/${state.currentServerId}`, { cmd }, 'POST');
+      const reply = await runRconCommand(cmd);
       ui.log('> ' + cmd);
       if (reply?.Message) ui.log(reply.Message.trim());
       cmdInput.value = '';
     } catch (err) {
+      if (errorCode(err) === 'no_server_selected') {
+        ui.log('Select a server before sending commands.');
+        return;
+      }
       if (errorCode(err) === 'unauthorized') handleUnauthorized();
       else ui.log('Command failed: ' + describeError(err));
     }
-  }
-
-  async function syncFromSteam() {
-    const raw = prompt('Enter comma-separated Steam64 IDs to sync:');
-    if (!raw) return;
-    const steamids = raw.split(',').map((s) => s.trim()).filter(Boolean);
-    if (steamids.length === 0) return;
-    try {
-      const res = await api('/api/steam/sync', { steamids }, 'POST');
-      ui.log('Synced ' + res.updated + ' players from Steam');
-      await loadPlayers();
-    } catch (err) {
-      if (errorCode(err) === 'unauthorized') handleUnauthorized();
-      else ui.log('Sync failed: ' + describeError(err));
-    }
-  }
-
-  function setupQuickButtons() {
-    document.querySelectorAll('[data-quick]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        if (!cmdInput) return;
-        cmdInput.value = btn.getAttribute('data-quick') || '';
-        cmdInput.focus();
-      });
-    });
   }
 
   function bindEvents() {
@@ -771,7 +873,6 @@
     });
     btnRefreshServers?.addEventListener('click', () => refreshServers());
     btnClearConsole?.addEventListener('click', () => ui.clearConsole());
-    btnSyncPlayers?.addEventListener('click', syncFromSteam);
     btnCreateUser?.addEventListener('click', async () => {
       if (state.currentUser?.role !== 'admin') return;
       hideNotice(userFeedback);
@@ -806,7 +907,6 @@
     const storedBase = localStorage.getItem('apiBase') || apiBaseInput?.value || 'http://localhost:8787';
     setApiBase(storedBase || 'http://localhost:8787');
     bindEvents();
-    setupQuickButtons();
     if (state.TOKEN) {
       await attemptSessionResume();
     } else {

--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1,0 +1,427 @@
+(function(){
+  if (typeof window.registerModule !== 'function') return;
+
+  const COLOR_PALETTE = ['#f97316','#22d3ee','#a855f7','#84cc16','#ef4444','#facc15','#14b8a6','#e11d48','#3b82f6','#8b5cf6','#10b981','#fb7185'];
+  const POLL_INTERVAL = 20000;
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function formatDuration(seconds) {
+    if (!Number.isFinite(seconds)) return '—';
+    const total = Math.max(0, Math.floor(seconds));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m`;
+    return `${total % 60}s`;
+  }
+
+  function formatHealth(value) {
+    if (!Number.isFinite(value)) return '—';
+    return `${Math.round(value)}`;
+  }
+
+  function formatPing(value) {
+    if (!Number.isFinite(value)) return '—';
+    return `${Math.round(value)}ms`;
+  }
+
+  function generateColor(index) {
+    const hue = (index * 137.508) % 360;
+    return `hsl(${hue}, 70%, 55%)`;
+  }
+
+  window.registerModule({
+    id: 'live-map',
+    title: 'Live map',
+    order: 20,
+    setup(ctx){
+      ctx.root?.classList.add('module-card','live-map-card');
+
+      const message = document.createElement('p');
+      message.className = 'module-message hidden';
+      ctx.body?.appendChild(message);
+
+      const layout = document.createElement('div');
+      layout.className = 'map-layout';
+      ctx.body?.appendChild(layout);
+
+      const mapView = document.createElement('div');
+      mapView.className = 'map-view';
+      const mapImage = document.createElement('img');
+      mapImage.alt = 'Rust world map';
+      mapImage.loading = 'lazy';
+      const overlay = document.createElement('div');
+      overlay.className = 'map-overlay';
+      mapView.appendChild(mapImage);
+      mapView.appendChild(overlay);
+
+      const sidebar = document.createElement('div');
+      sidebar.className = 'map-sidebar';
+
+      const summary = document.createElement('div');
+      summary.className = 'map-summary';
+      sidebar.appendChild(summary);
+
+      const filterRow = document.createElement('div');
+      filterRow.className = 'row';
+      const clearBtn = document.createElement('button');
+      clearBtn.className = 'ghost small';
+      clearBtn.textContent = 'Show everyone';
+      clearBtn.disabled = true;
+      filterRow.appendChild(clearBtn);
+      sidebar.appendChild(filterRow);
+
+      const listWrap = document.createElement('div');
+      listWrap.className = 'map-player-list';
+      sidebar.appendChild(listWrap);
+
+      const teamInfo = document.createElement('div');
+      teamInfo.className = 'map-team-info';
+      sidebar.appendChild(teamInfo);
+
+      layout.appendChild(mapView);
+      layout.appendChild(sidebar);
+
+      const state = {
+        serverId: null,
+        players: [],
+        mapMeta: null,
+        serverInfo: null,
+        teamColors: new Map(),
+        selectedTeam: null,
+        selectedSolo: null,
+        lastUpdated: null,
+        pollTimer: null
+      };
+
+      function setMessage(text) {
+        if (!message) return;
+        message.textContent = text;
+        message.classList.remove('hidden');
+      }
+
+      function clearMessage() {
+        message?.classList.add('hidden');
+      }
+
+      function stopPolling() {
+        if (state.pollTimer) {
+          clearInterval(state.pollTimer);
+          state.pollTimer = null;
+        }
+      }
+
+      function schedulePolling() {
+        stopPolling();
+        if (!state.serverId) return;
+        state.pollTimer = setInterval(() => {
+          refreshData('poll').catch((err) => ctx.log?.('Map refresh failed: ' + (err?.message || err)));
+        }, POLL_INTERVAL);
+      }
+
+      function teamKey(player) {
+        return Number(player?.teamId) > 0 ? Number(player.teamId) : 0;
+      }
+
+      function ensureTeamColors(players) {
+        const presentTeams = new Set();
+        let index = 0;
+        for (const player of players) {
+          const key = teamKey(player);
+          if (key <= 0) continue;
+          presentTeams.add(key);
+          if (!state.teamColors.has(key)) {
+            const color = COLOR_PALETTE[index] || generateColor(index);
+            state.teamColors.set(key, color);
+            index += 1;
+          }
+        }
+        for (const key of [...state.teamColors.keys()]) {
+          if (!presentTeams.has(key)) state.teamColors.delete(key);
+        }
+      }
+
+      function colorForPlayer(player) {
+        const key = teamKey(player);
+        if (key > 0 && state.teamColors.has(key)) return state.teamColors.get(key);
+        if (key > 0) {
+          const fallbackIndex = state.teamColors.size;
+          const color = COLOR_PALETTE[fallbackIndex] || generateColor(fallbackIndex);
+          state.teamColors.set(key, color);
+          return color;
+        }
+        const sid = player?.steamId || '';
+        let hash = 0;
+        for (let i = 0; i < sid.length; i++) hash = (hash * 31 + sid.charCodeAt(i)) >>> 0;
+        const hue = (hash % 360);
+        return `hsl(${hue}, 12%, 72%)`;
+      }
+
+      function mapReady() {
+        return state.mapMeta && Number.isFinite(state.mapMeta.size) && state.mapMeta.size > 0;
+      }
+
+      function projectPosition(position) {
+        if (!mapReady()) return null;
+        const size = state.mapMeta.size;
+        const x = Number(position?.x) || 0;
+        const z = Number(position?.z) || 0;
+        const px = clamp(((x + size / 2) / size) * 100, 0, 100);
+        const pz = clamp(((z + size / 2) / size) * 100, 0, 100);
+        return { left: px, top: 100 - pz };
+      }
+
+      function updateMapImage(meta) {
+        if (!meta?.imageUrl && !meta?.rawImageUrl) {
+          mapImage.removeAttribute('src');
+          return;
+        }
+        const next = meta.imageUrl || meta.rawImageUrl;
+        if (mapImage.getAttribute('src') !== next) {
+          mapImage.src = next;
+        }
+      }
+
+      function shouldDisplay(player) {
+        if (state.selectedSolo) return player.steamId === state.selectedSolo;
+        if (state.selectedTeam) return Number(player.teamId) === state.selectedTeam;
+        return true;
+      }
+
+      function renderMarkers() {
+        overlay.innerHTML = '';
+        if (!mapReady()) return;
+        for (const player of state.players) {
+          const position = projectPosition(player.position);
+          if (!position) continue;
+          const marker = document.createElement('div');
+          marker.className = 'map-marker';
+          marker.style.backgroundColor = colorForPlayer(player);
+          marker.style.left = position.left + '%';
+          marker.style.top = position.top + '%';
+          marker.title = player.displayName || player.persona || player.steamId;
+          if (!shouldDisplay(player)) marker.classList.add('dimmed');
+          if (state.selectedSolo && state.selectedSolo === player.steamId) marker.classList.add('active');
+          if (!state.selectedSolo && state.selectedTeam && Number(player.teamId) === state.selectedTeam) marker.classList.add('active');
+          marker.addEventListener('click', (e) => {
+            e.stopPropagation();
+            selectPlayer(player);
+          });
+          overlay.appendChild(marker);
+        }
+      }
+
+      function renderPlayerList() {
+        listWrap.innerHTML = '';
+        const players = state.players.filter((p) => shouldDisplay(p));
+        if (players.length === 0) {
+          const empty = document.createElement('p');
+          empty.className = 'module-message';
+          empty.textContent = state.serverId ? 'No players online for this selection.' : 'Connect to a server to view live positions.';
+          listWrap.appendChild(empty);
+          return;
+        }
+        for (const player of players) {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.textContent = player.displayName || player.persona || player.steamId;
+          const tag = document.createElement('span');
+          tag.className = 'map-player-tag';
+          tag.innerHTML = `<span>${formatPing(player.ping)}</span><span>${formatHealth(player.health)} hp</span>`;
+          btn.appendChild(tag);
+          if (state.selectedSolo && state.selectedSolo === player.steamId) btn.classList.add('active');
+          if (!state.selectedSolo && state.selectedTeam && Number(player.teamId) === state.selectedTeam) btn.classList.add('active');
+          btn.style.borderLeft = `4px solid ${colorForPlayer(player)}`;
+          btn.addEventListener('click', () => selectPlayer(player));
+          listWrap.appendChild(btn);
+        }
+      }
+
+      function renderSummary() {
+        summary.innerHTML = '';
+        const total = state.players.length;
+        const teamCounts = new Map();
+        let soloCount = 0;
+        for (const p of state.players) {
+          const key = teamKey(p);
+          if (key > 0) teamCounts.set(key, (teamCounts.get(key) || 0) + 1);
+          else soloCount += 1;
+        }
+        const mapName = state.serverInfo?.mapName || state.serverInfo?.map || 'Procedural Map';
+        const metaLines = [
+          { label: 'Players online', value: total },
+          { label: 'Teams', value: teamCounts.size },
+          { label: 'Solo players', value: soloCount }
+        ];
+        if (state.mapMeta?.size) metaLines.push({ label: 'World size', value: state.mapMeta.size });
+        if (state.mapMeta?.seed) metaLines.push({ label: 'Seed', value: state.mapMeta.seed });
+        if (state.lastUpdated) {
+          const ts = new Date(state.lastUpdated);
+          metaLines.push({ label: 'Updated', value: ts.toLocaleTimeString() });
+        }
+        const title = document.createElement('div');
+        title.innerHTML = `<strong>${mapName}</strong>`;
+        summary.appendChild(title);
+        for (const item of metaLines) {
+          const row = document.createElement('div');
+          row.innerHTML = `<strong>${item.value ?? '—'}</strong> ${item.label}`;
+          summary.appendChild(row);
+        }
+      }
+
+      function renderTeamInfo() {
+        teamInfo.innerHTML = '';
+        if (!state.players.length) {
+          teamInfo.innerHTML = '<strong>No live data</strong><p class="muted">Connect to a server to see team breakdowns.</p>';
+          return;
+        }
+        if (!state.selectedTeam && !state.selectedSolo) {
+          teamInfo.innerHTML = '<strong>Select a player</strong><p class="muted">Click a player or marker to focus on their team.</p>';
+          return;
+        }
+        const collection = state.selectedSolo
+          ? state.players.filter((p) => p.steamId === state.selectedSolo)
+          : state.players.filter((p) => Number(p.teamId) === state.selectedTeam);
+        if (collection.length === 0) {
+          teamInfo.innerHTML = '<strong>No matching players</strong><p class="muted">They might have disconnected.</p>';
+          return;
+        }
+        const color = colorForPlayer(collection[0]);
+        const heading = document.createElement('div');
+        heading.innerHTML = `<strong>${state.selectedSolo ? 'Solo player' : 'Team ' + state.selectedTeam}</strong>`;
+        const colorChip = document.createElement('span');
+        colorChip.className = 'map-color-chip';
+        colorChip.style.background = color;
+        heading.appendChild(document.createTextNode(' '));
+        heading.appendChild(colorChip);
+        teamInfo.appendChild(heading);
+        const detail = document.createElement('p');
+        detail.className = 'muted';
+        detail.textContent = state.selectedSolo ? 'Individual survivor stats' : `${collection.length} member(s)`;
+        teamInfo.appendChild(detail);
+        const list = document.createElement('ul');
+        list.className = 'map-team-members';
+        for (const player of collection) {
+          const li = document.createElement('li');
+          const name = document.createElement('span');
+          name.textContent = player.displayName || player.persona || player.steamId;
+          const stats = document.createElement('span');
+          stats.textContent = `${formatHealth(player.health)} hp · ${formatDuration(player.connectedSeconds)}`;
+          li.appendChild(name);
+          li.appendChild(stats);
+          list.appendChild(li);
+        }
+        teamInfo.appendChild(list);
+      }
+
+      function renderAll() {
+        ensureTeamColors(state.players);
+        updateMapImage(state.mapMeta);
+        renderMarkers();
+        renderPlayerList();
+        renderSummary();
+        renderTeamInfo();
+        clearBtn.disabled = !state.selectedSolo && !state.selectedTeam;
+      }
+
+      function clearSelection() {
+        state.selectedTeam = null;
+        state.selectedSolo = null;
+        renderAll();
+      }
+
+      function selectPlayer(player) {
+        const key = teamKey(player);
+        if (key > 0) {
+          state.selectedTeam = state.selectedTeam === key ? null : key;
+          state.selectedSolo = null;
+        } else {
+          state.selectedSolo = state.selectedSolo === player.steamId ? null : player.steamId;
+          state.selectedTeam = null;
+        }
+        renderAll();
+      }
+
+      clearBtn.addEventListener('click', () => clearSelection());
+      mapView.addEventListener('click', () => clearSelection());
+
+      async function refreshData(reason){
+        if (!state.serverId) return;
+        try {
+          setMessage('Loading live map data…');
+          const data = await ctx.api(`/api/servers/${state.serverId}/live-map`);
+          state.players = Array.isArray(data?.players) ? data.players : [];
+          state.mapMeta = data?.map || null;
+          state.serverInfo = data?.info || null;
+          state.lastUpdated = data?.fetchedAt || new Date().toISOString();
+          if (!mapReady()) {
+            setMessage('Map metadata unavailable. Add a RustMaps API key to the backend configuration.');
+          } else {
+            clearMessage();
+          }
+          renderAll();
+        } catch (err) {
+          if (ctx.errorCode?.(err) === 'unauthorized') {
+            ctx.handleUnauthorized?.();
+            return;
+          }
+          const detail = ctx.describeError?.(err) || err?.message || 'Unable to fetch live map data.';
+          setMessage(detail);
+          ctx.log?.('Live map error: ' + (err?.message || err));
+        }
+      }
+
+      const offConnect = ctx.on?.('server:connected', ({ serverId }) => {
+        if (!serverId) return;
+        state.serverId = serverId;
+        clearSelection();
+        refreshData('server-connected');
+        schedulePolling();
+      });
+
+      const offDisconnect = ctx.on?.('server:disconnected', ({ serverId }) => {
+        if (state.serverId && serverId === state.serverId) {
+          stopPolling();
+          state.serverId = null;
+          state.players = [];
+          state.mapMeta = null;
+          state.serverInfo = null;
+          state.lastUpdated = null;
+          clearSelection();
+          overlay.innerHTML = '';
+          mapImage.removeAttribute('src');
+          renderPlayerList();
+          renderSummary();
+          renderTeamInfo();
+          setMessage('Connect to a server to load the live map.');
+        }
+      });
+
+      const offLogout = ctx.on?.('auth:logout', () => {
+        stopPolling();
+        state.serverId = null;
+        state.players = [];
+        state.mapMeta = null;
+        state.serverInfo = null;
+        state.lastUpdated = null;
+        clearSelection();
+        overlay.innerHTML = '';
+        mapImage.removeAttribute('src');
+        renderPlayerList();
+        renderSummary();
+        renderTeamInfo();
+        setMessage('Sign in and connect to a server to view the live map.');
+      });
+
+      ctx.onCleanup?.(() => offConnect?.());
+      ctx.onCleanup?.(() => offDisconnect?.());
+      ctx.onCleanup?.(() => offLogout?.());
+      ctx.onCleanup?.(() => stopPolling());
+
+      setMessage('Connect to a server to load the live map.');
+    }
+  });
+})();

--- a/frontend/assets/modules/module-loader.js
+++ b/frontend/assets/modules/module-loader.js
@@ -1,0 +1,76 @@
+(() => {
+  const registry = [];
+  const active = new Map();
+
+  function normalizeModule(definition) {
+    if (!definition || typeof definition !== 'object') throw new Error('Module definition must be an object');
+    if (!definition.id) throw new Error('Module must declare an id');
+    return {
+      order: typeof definition.order === 'number' ? definition.order : 0,
+      ...definition
+    };
+  }
+
+  function registerModule(definition) {
+    const normalized = normalizeModule(definition);
+    if (registry.some((mod) => mod.id === normalized.id)) {
+      console.warn(`Module with id "${normalized.id}" already registered. Skipping duplicate.`);
+      return;
+    }
+    registry.push(normalized);
+  }
+
+  function initModules(hostContext) {
+    if (!hostContext || typeof hostContext.createCard !== 'function') {
+      throw new Error('Module host context requires a createCard function');
+    }
+    const modules = [...registry].sort((a, b) => a.order - b.order);
+    for (const mod of modules) {
+      const view = hostContext.createCard({ id: mod.id, title: mod.title || mod.id, icon: mod.icon });
+      const cleanup = [];
+      const moduleContext = {
+        ...hostContext,
+        module: mod,
+        root: view?.card || null,
+        body: view?.body || null,
+        header: view?.header || null,
+        actions: view?.actions || null,
+        setTitle: view?.setTitle || (() => {}),
+        removeCard: view?.remove || (() => {}),
+        onCleanup(fn) {
+          if (typeof fn === 'function') cleanup.push(fn);
+        }
+      };
+      try {
+        const result = typeof mod.setup === 'function' ? mod.setup(moduleContext) : null;
+        if (typeof result === 'function') cleanup.push(result);
+      } catch (err) {
+        console.error(`Failed to initialise module ${mod.id}:`, err);
+      }
+      active.set(mod.id, { definition: mod, view, cleanup });
+    }
+  }
+
+  function destroyModule(id) {
+    const entry = active.get(id);
+    if (!entry) return;
+    for (const fn of entry.cleanup || []) {
+      try { fn(); } catch (err) { console.error(`Cleanup failed for module ${id}:`, err); }
+    }
+    active.delete(id);
+    entry.view?.remove?.();
+  }
+
+  function listModules() {
+    return [...registry];
+  }
+
+  window.ModuleLoader = {
+    register: registerModule,
+    init: initModules,
+    destroy: destroyModule,
+    list: listModules,
+    get(id) { return active.get(id) || null; }
+  };
+  window.registerModule = registerModule;
+})();

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -1,0 +1,130 @@
+(function(){
+  if (typeof window.registerModule !== 'function') return;
+
+  window.registerModule({
+    id: 'players-directory',
+    title: 'Players',
+    order: 10,
+    setup(ctx){
+      const list = document.createElement('ul');
+      list.className = 'player-directory';
+      const message = document.createElement('p');
+      message.className = 'module-message hidden';
+      message.textContent = 'Sign in to view player directory.';
+      ctx.body?.appendChild(list);
+      ctx.body?.appendChild(message);
+
+      if (ctx.actions) {
+        ctx.actions.classList.add('module-header-actions');
+        const syncBtn = document.createElement('button');
+        syncBtn.id = 'moduleSyncPlayers';
+        syncBtn.className = 'ghost small';
+        syncBtn.textContent = 'Sync from Steam';
+        syncBtn.addEventListener('click', async () => {
+          const raw = window.prompt('Enter comma-separated Steam64 IDs to sync:');
+          if (!raw) return;
+          const steamids = raw.split(',').map((s) => s.trim()).filter(Boolean);
+          if (steamids.length === 0) return;
+          try {
+            await ctx.api('/api/steam/sync', { steamids }, 'POST');
+            ctx.log?.(`Requested Steam sync for ${steamids.length} player(s).`);
+            await refresh('steam-sync');
+          } catch (err) {
+            if (ctx.errorCode?.(err) === 'unauthorized') ctx.handleUnauthorized?.();
+            else ctx.log?.('Steam sync failed: ' + (ctx.describeError?.(err) || err?.message || String(err)));
+          }
+        });
+        ctx.actions.appendChild(syncBtn);
+      }
+
+      function setMessage(text, variant = 'info') {
+        if (!message) return;
+        message.textContent = text;
+        message.classList.remove('hidden');
+        message.dataset.variant = variant;
+      }
+
+      function clearMessage() {
+        message?.classList.add('hidden');
+        message?.removeAttribute('data-variant');
+      }
+
+      function render(players) {
+        list.innerHTML = '';
+        if (!Array.isArray(players) || players.length === 0) {
+          setMessage('No tracked players yet. Import Steam profiles to populate this list.');
+          return;
+        }
+        clearMessage();
+        for (const p of players) {
+          const li = document.createElement('li');
+          const left = document.createElement('div');
+          const strong = document.createElement('strong');
+          strong.textContent = p.persona || p.steamid;
+          left.appendChild(strong);
+          const meta = document.createElement('div');
+          meta.className = 'muted small';
+          meta.textContent = p.steamid;
+          left.appendChild(meta);
+          const right = document.createElement('div');
+          right.className = 'server-actions';
+          if (p.country) {
+            const badge = document.createElement('span');
+            badge.className = 'badge';
+            badge.textContent = p.country;
+            right.appendChild(badge);
+          }
+          if (p.vac_banned) {
+            const badge = document.createElement('span');
+            badge.className = 'badge';
+            badge.textContent = 'VAC';
+            right.appendChild(badge);
+          }
+          li.appendChild(left);
+          li.appendChild(right);
+          list.appendChild(li);
+        }
+      }
+
+      let isLoading = false;
+      async function refresh(reason){
+        if (isLoading) return;
+        const state = ctx.getState?.();
+        if (!state?.currentUser) {
+          list.innerHTML = '';
+          setMessage('Sign in to view player directory.');
+          return;
+        }
+        isLoading = true;
+        setMessage('Loading players…');
+        try {
+          const players = await ctx.api('/api/players?limit=200');
+          render(players);
+        } catch (err) {
+          if (ctx.errorCode?.(err) === 'unauthorized') {
+            ctx.handleUnauthorized?.();
+          } else {
+            setMessage('Unable to load players: ' + (ctx.describeError?.(err) || err?.message || 'Unknown error'));
+            ctx.log?.('Players module error: ' + (err?.message || err));
+          }
+        } finally {
+          isLoading = false;
+        }
+      }
+
+      const offLogin = ctx.on?.('auth:login', () => refresh('login'));
+      const offRefresh = ctx.on?.('players:refresh', (payload) => refresh(payload?.reason || 'manual'));
+      const offLogout = ctx.on?.('auth:logout', () => {
+        list.innerHTML = '';
+        setMessage('Sign in to view player directory.');
+      });
+
+      ctx.onCleanup?.(() => offLogin?.());
+      ctx.onCleanup?.(() => offRefresh?.());
+      ctx.onCleanup?.(() => offLogout?.());
+
+      // Initial state when module mounts
+      refresh('init');
+    }
+  });
+})();

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -14,6 +14,12 @@
 body{margin:0;min-height:100vh;background:radial-gradient(circle at 20% 20%,rgba(45,212,191,.12),transparent 40%),radial-gradient(circle at 80% 0,rgba(14,165,233,.08),transparent 45%),linear-gradient(180deg,#020409,#060a11);color:var(--text)}
 .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px}
 .topbar{display:flex;justify-content:space-between;align-items:center;margin-bottom:32px;gap:16px}
+.topbar-title{display:flex;flex-direction:column;gap:8px}
+.topnav{display:flex;gap:8px;align-items:center}
+.topnav .nav-btn{padding:6px 12px;border-radius:10px;font-size:14px;border:1px solid transparent;background:transparent;color:var(--muted)}
+.topnav .nav-btn:hover{color:var(--accent)}
+.topnav .nav-btn.active{color:var(--accent);border-color:rgba(94,234,212,0.45);background:rgba(94,234,212,0.12)}
+.topnav.hidden{display:none}
 h1{margin:0;font-size:26px;font-weight:600}
 h2{margin-top:0;font-size:24px;font-weight:600}
 h3{margin:0;font-size:20px;font-weight:600}
@@ -32,6 +38,12 @@ h4{margin:24px 0 8px;font-size:16px;font-weight:600}
 .card-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px}
 .card-header h3{font-size:18px}
 
+.settings-card{max-width:520px;margin:0 auto}
+.settings-body{display:flex;flex-direction:column;gap:16px}
+.settings-body label{display:flex;flex-direction:column;gap:6px;font-size:14px;color:var(--muted)}
+.settings-hint{font-size:13px;color:var(--muted);border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.04);border-radius:12px;padding:12px;line-height:1.6}
+.settings-hint code{background:#0b131f;padding:2px 6px;border-radius:6px;color:var(--accent);font-family:"JetBrains Mono",monospace;font-size:12px}
+
 input,button,select{font-size:15px}
 input,select{padding:10px 12px;border-radius:12px;border:1px solid #1f2b3d;background:var(--bg-alt);color:var(--text)}
 select{appearance:none;background-image:url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" fill="none"%3E%3Cpath d="M1 1.5L6 6.5L11 1.5" stroke="%23dbe8ef" stroke-width="1.4" stroke-linecap="round"/%3E%3C/svg%3E');background-repeat:no-repeat;background-position:right 12px center;padding-right:34px}
@@ -44,6 +56,8 @@ button.ghost:hover{border-color:#31506d}
 button.icon{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:50%;background:transparent;border:1px solid #243244}
 button.icon:hover{border-color:var(--accent-strong);color:var(--accent)}
 button.small{padding:6px 10px;font-size:13px;border-radius:10px}
+button.link{border:none;background:transparent;color:var(--accent);padding:0;font-size:14px}
+button.link:hover{color:#fff}
 
 .row{display:flex;gap:10px;align-items:center;margin-top:12px}
 .row.quick-row{flex-wrap:wrap}
@@ -112,6 +126,11 @@ ul{list-style:none;padding:0;margin:0}
 .live-map-card .map-team-members{list-style:none;margin:8px 0 0;padding:0;display:grid;gap:6px}
 .live-map-card .map-team-members li{display:flex;justify-content:space-between;gap:10px;font-size:13px;color:var(--muted)}
 .map-color-chip{display:inline-block;width:14px;height:14px;border-radius:50%;border:2px solid rgba(0,0,0,0.4);box-shadow:0 0 0 1px rgba(255,255,255,0.1)}
+.map-upload{border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:12px;background:#0b131f;display:flex;flex-direction:column;gap:10px}
+.map-upload p{margin:0;font-size:13px;color:var(--muted)}
+.map-upload-actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.map-upload input[type=file]{padding:6px;background:transparent;border:none;color:var(--muted)}
+.map-upload .notice{margin:0}
 
 @media(max-width:720px){
   .wrap{padding:24px 16px 48px}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -66,9 +66,9 @@ ul{list-style:none;padding:0;margin:0}
 .server-meta{display:flex;flex-wrap:wrap;gap:10px;font-size:13px;color:var(--muted)}
 .server-actions{display:flex;gap:8px;align-items:center}
 
-#players li,#userList li{display:flex;justify-content:space-between;align-items:flex-start;border-bottom:1px solid rgba(255,255,255,0.06);padding:10px 0;gap:12px}
-#players li:last-child,#userList li:last-child{border-bottom:none}
-#players li strong{display:block;font-size:15px}
+.player-directory li,#userList li{display:flex;justify-content:space-between;align-items:flex-start;border-bottom:1px solid rgba(255,255,255,0.06);padding:10px 0;gap:12px}
+.player-directory li:last-child,#userList li:last-child{border-bottom:none}
+.player-directory li strong{display:block;font-size:15px}
 .badge{background:#102233;border:1px solid #1e3347;border-radius:999px;padding:3px 8px;font-size:11px;color:var(--accent);text-transform:uppercase;letter-spacing:.05em}
 
 .notice{margin-top:12px;padding:10px 12px;border-radius:12px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.08);font-size:14px;color:var(--muted)}
@@ -84,9 +84,44 @@ ul{list-style:none;padding:0;margin:0}
 #servers button.connect{align-self:flex-start}
 #servers .status-details{font-size:12px;color:var(--muted)}
 
+.module-stack{display:flex;flex-direction:column;gap:20px}
+.module-card .module-body{display:flex;flex-direction:column;gap:16px}
+.module-card .module-header-actions{display:flex;gap:8px;align-items:center}
+.module-card .module-header-actions:empty{display:none}
+.module-message{font-size:14px;color:var(--muted)}
+
+.player-directory{max-height:360px;overflow:auto}
+
+.live-map-card .map-layout{display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start}
+.live-map-card .map-view{position:relative;flex:1 1 260px;min-height:280px;background:#070b13;border:1px solid #182233;border-radius:16px;overflow:hidden}
+.live-map-card .map-view img{width:100%;height:100%;object-fit:cover;display:block;filter:saturate(1.05)}
+.live-map-card .map-overlay{position:absolute;top:0;left:0;right:0;bottom:0;pointer-events:none}
+.live-map-card .map-marker{position:absolute;width:12px;height:12px;border-radius:50%;border:2px solid rgba(0,0,0,0.6);box-shadow:0 0 0 2px rgba(0,0,0,0.2),0 4px 10px rgba(0,0,0,0.6);transform:translate(-50%,-50%);pointer-events:auto;cursor:pointer;transition:transform .12s ease,opacity .12s ease}
+.live-map-card .map-marker.dimmed{opacity:.25}
+.live-map-card .map-marker.active{transform:translate(-50%,-50%) scale(1.2);box-shadow:0 0 0 3px rgba(0,0,0,0.4),0 6px 14px rgba(0,0,0,0.8)}
+.live-map-card .map-sidebar{flex:0 0 220px;display:flex;flex-direction:column;gap:12px}
+.live-map-card .map-summary{display:grid;gap:4px;font-size:14px;color:var(--muted)}
+.live-map-card .map-summary strong{color:var(--text);font-size:15px}
+.live-map-card .map-player-list{flex:1 1 auto;overflow:auto;max-height:280px;border:1px solid rgba(255,255,255,0.05);border-radius:14px;padding:10px;background:#0a121d}
+.live-map-card .map-player-list button{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:8px 10px;border-radius:10px;border:1px solid transparent;background:transparent;color:var(--text);font-size:14px;text-align:left;cursor:pointer}
+.live-map-card .map-player-list button:hover{border-color:rgba(94,234,212,0.35);background:rgba(94,234,212,0.08)}
+.live-map-card .map-player-list button.active{border-color:rgba(94,234,212,0.45);background:rgba(94,234,212,0.12)}
+.live-map-card .map-player-tag{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--muted)}
+.live-map-card .map-team-info{border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:12px;background:#0b131f;font-size:14px;color:var(--muted)}
+.live-map-card .map-team-info strong{display:block;color:var(--text);margin-bottom:6px}
+.live-map-card .map-team-members{list-style:none;margin:8px 0 0;padding:0;display:grid;gap:6px}
+.live-map-card .map-team-members li{display:flex;justify-content:space-between;gap:10px;font-size:13px;color:var(--muted)}
+.map-color-chip{display:inline-block;width:14px;height:14px;border-radius:50%;border:2px solid rgba(0,0,0,0.4);box-shadow:0 0 0 1px rgba(255,255,255,0.1)}
+
 @media(max-width:720px){
   .wrap{padding:24px 16px 48px}
   .auth-card{padding:20px}
   .card{padding:16px}
   .grid3{grid-template-columns:1fr}
+}
+
+@media(max-width:1100px){
+  .live-map-card .map-layout{flex-direction:column}
+  .live-map-card .map-sidebar{width:100%;flex:0 0 auto}
+  .live-map-card .map-player-list{max-height:220px}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,21 +69,10 @@
             <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
             <button id="btnSend" class="accent">Send</button>
           </div>
-          <div class="row quick-row">
-            <button data-quick="status" class="ghost">status</button>
-            <button data-quick="serverinfo" class="ghost">serverinfo</button>
-            <button data-quick='say "Hello from panel"' class="ghost">say</button>
-            <button data-quick="playerlist" class="ghost">playerlist</button>
-          </div>
+          <div class="row quick-row" id="quickCommands"></div>
         </div>
 
-        <div class="card">
-          <div class="card-header">
-            <h3>Players</h3>
-            <button id="btnSyncPlayers" class="ghost small">Sync from Steam</button>
-          </div>
-          <ul id="players"></ul>
-        </div>
+        <div id="moduleColumn" class="module-stack"></div>
       </div>
 
       <div id="userCard" class="card hidden">
@@ -113,6 +102,9 @@
     </section>
   </div>
 
+  <script src="assets/modules/module-loader.js"></script>
+  <script src="assets/modules/players.js"></script>
+  <script src="assets/modules/map.js"></script>
   <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" crossorigin="anonymous"></script>
   <script src="assets/app.js"></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,13 @@
 <body>
   <div class="wrap">
     <header class="topbar">
-      <h1>Rust Admin Online — Open Source</h1>
+      <div class="topbar-title">
+        <h1>Rust Admin Online — Open Source</h1>
+        <nav id="mainNav" class="topnav hidden">
+          <button id="navDashboard" type="button" class="nav-btn active">Dashboard</button>
+          <button id="navSettings" type="button" class="nav-btn">Settings</button>
+        </nav>
+      </div>
       <div id="userBox" class="muted"></div>
     </header>
 
@@ -39,66 +45,89 @@
     </section>
 
     <section id="appPanel" class="hidden">
-      <div class="grid3" id="mainGrid">
-        <div class="card" id="serversCard">
-          <div class="card-header">
-            <h3>Servers</h3>
-            <button id="btnRefreshServers" class="icon" title="Refresh">⟳</button>
-          </div>
-          <ul id="servers"></ul>
-          <details>
-            <summary>Add server</summary>
-            <div class="grid2">
-              <input id="svName" placeholder="Name">
-              <input id="svHost" placeholder="Host/IP">
-              <input id="svPort" type="number" placeholder="RCON Port" value="28017">
-              <input id="svPass" placeholder="Password">
+      <div id="dashboardPanel">
+        <div class="grid3" id="mainGrid">
+          <div class="card" id="serversCard">
+            <div class="card-header">
+              <h3>Servers</h3>
+              <button id="btnRefreshServers" class="icon" title="Refresh">⟳</button>
             </div>
-            <label class="inline"><input type="checkbox" id="svTLS"> Use TLS (wss)</label>
-            <button id="btnAddServer" class="ghost">Add server</button>
-          </details>
+            <ul id="servers"></ul>
+            <details>
+              <summary>Add server</summary>
+              <div class="grid2">
+                <input id="svName" placeholder="Name">
+                <input id="svHost" placeholder="Host/IP">
+                <input id="svPort" type="number" placeholder="RCON Port" value="28017">
+                <input id="svPass" placeholder="Password">
+              </div>
+              <label class="inline"><input type="checkbox" id="svTLS"> Use TLS (wss)</label>
+              <button id="btnAddServer" class="ghost">Add server</button>
+            </details>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3>Console</h3>
+              <button id="btnClearConsole" class="icon" title="Clear console">✕</button>
+            </div>
+            <pre id="console"></pre>
+            <div class="row">
+              <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
+              <button id="btnSend" class="accent">Send</button>
+            </div>
+            <div class="row quick-row" id="quickCommands"></div>
+          </div>
+
+          <div id="moduleColumn" class="module-stack"></div>
         </div>
 
-        <div class="card">
+        <div id="userCard" class="card hidden">
           <div class="card-header">
-            <h3>Console</h3>
-            <button id="btnClearConsole" class="icon" title="Clear console">✕</button>
+            <h3>Team access</h3>
           </div>
-          <pre id="console"></pre>
-          <div class="row">
-            <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
-            <button id="btnSend" class="accent">Send</button>
+          <div class="user-create">
+            <h4>Invite a teammate</h4>
+            <div class="grid2 stack-sm">
+              <input id="newUserName" placeholder="Username">
+              <input id="newUserPassword" type="password" placeholder="Temporary password">
+            </div>
+            <label>Role
+              <select id="newUserRole">
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+            <div class="row">
+              <button id="btnCreateUser" class="accent">Create user</button>
+            </div>
+            <p id="userFeedback" class="notice hidden"></p>
           </div>
-          <div class="row quick-row" id="quickCommands"></div>
+          <h4>Existing users</h4>
+          <ul id="userList" class="users"></ul>
         </div>
-
-        <div id="moduleColumn" class="module-stack"></div>
       </div>
 
-      <div id="userCard" class="card hidden">
-        <div class="card-header">
-          <h3>Team access</h3>
-        </div>
-        <div class="user-create">
-          <h4>Invite a teammate</h4>
-          <div class="grid2 stack-sm">
-            <input id="newUserName" placeholder="Username">
-            <input id="newUserPassword" type="password" placeholder="Temporary password">
+      <section id="settingsPanel" class="hidden">
+        <div class="card settings-card">
+          <div class="card-header">
+            <h3>Personal settings</h3>
           </div>
-          <label>Role
-            <select id="newUserRole">
-              <option value="user">User</option>
-              <option value="admin">Admin</option>
-            </select>
-          </label>
-          <div class="row">
-            <button id="btnCreateUser" class="accent">Create user</button>
+          <div class="settings-body">
+            <p class="muted">Your RustMaps API key is stored per user. The map is cached after the first successful download each wipe and reset on the first Thursday of every month.</p>
+            <label>RustMaps API key
+              <input id="rustMapsKey" placeholder="pk_live_..." autocomplete="off">
+            </label>
+            <div class="row">
+              <button id="btnSaveSettings" class="accent">Save settings</button>
+            </div>
+            <p id="settingsStatus" class="notice hidden"></p>
+            <div class="settings-hint">
+              <p>Missing imagery for custom maps? Run <code>world.rendermap</code> in RCON or the server console, wait for the render to finish inside your Rust server folder, and upload the image from the live map module.</p>
+            </div>
           </div>
-          <p id="userFeedback" class="notice hidden"></p>
         </div>
-        <h4>Existing users</h4>
-        <ul id="userList" class="users"></ul>
-      </div>
+      </section>
     </section>
   </div>
 


### PR DESCRIPTION
## Summary
- add a frontend module loader and quick-command registry so dashboard panels can be provided by independent modules
- convert the existing player directory into a module and add a live map module that renders team markers with RustMaps imagery
- expose a new `/api/servers/:id/live-map` endpoint backed by Rust RCON data and document the required `RUSTMAPS_API_KEY`

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3a89d7f948331b0e1cf99257cd0b7