### PR TITLE
Add dark themed server panel shell

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -130,5 +130,14 @@ function createApi(pool, dialect) {
       await exec('INSERT INTO server_maps(server_id,map_key,data,image_path,custom) VALUES(?,?,?,?,?) ON DUPLICATE KEY UPDATE map_key=VALUES(map_key), data=VALUES(data), image_path=VALUES(image_path), custom=VALUES(custom), updated_at=CURRENT_TIMESTAMP',[serverId,map_key,data,image_path,custom?1:0]);
     },
     async deleteServerMap(serverId){ await exec('DELETE FROM server_maps WHERE server_id=?',[serverId]); },
+    async countServerMapsByImagePath(imagePath, excludeServerId=null){
+      if (!imagePath) return 0;
+      if (Number.isFinite(excludeServerId)){
+        const rows = await exec('SELECT COUNT(*) c FROM server_maps WHERE image_path=? AND server_id!=?', [imagePath, excludeServerId]);
+        return rows?.[0]?.c ? Number(rows[0].c) : 0;
+      }
+      const rows = await exec('SELECT COUNT(*) c FROM server_maps WHERE image_path=?', [imagePath]);
+      return rows?.[0]?.c ? Number(rows[0].c) : 0;
+    }
   };
 }

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -134,5 +134,14 @@ function createApi(dbh, dialect) {
       await dbh.run("INSERT INTO server_maps(server_id,map_key,data,image_path,custom,created_at,updated_at) VALUES(?,?,?,?,?,datetime('now'),datetime('now')) ON CONFLICT(server_id) DO UPDATE SET map_key=excluded.map_key, data=excluded.data, image_path=excluded.image_path, custom=excluded.custom, updated_at=excluded.updated_at",[serverId,map_key,data,image_path,custom?1:0]);
     },
     async deleteServerMap(serverId){ await dbh.run('DELETE FROM server_maps WHERE server_id=?',[serverId]); },
+    async countServerMapsByImagePath(imagePath, excludeServerId=null){
+      if (!imagePath) return 0;
+      if (Number.isFinite(excludeServerId)) {
+        const row = await dbh.get('SELECT COUNT(*) c FROM server_maps WHERE image_path=? AND server_id!=?', [imagePath, excludeServerId]);
+        return row?.c ? Number(row.c) : 0;
+      }
+      const row = await dbh.get('SELECT COUNT(*) c FROM server_maps WHERE image_path=?', [imagePath]);
+      return row?.c ? Number(row.c) : 0;
+    }
   };
 }

--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -1,0 +1,130 @@
+:root{
+  --bg:#0b0c0f;
+  --bg-2:#0f1117;
+  --surface:#151823;
+  --surface-2:#1b2030;
+  --border:rgba(255,255,255,.06);
+  --text:#e8e9ef;
+  --muted:#a6adc8;
+  --accent:#e11d48;
+  --accent-2:#f97316;
+  --ok:#22c55e;
+  --warn:#f59e0b;
+  --bad:#ef4444;
+  --shadow:0 8px 28px rgba(0,0,0,.35);
+  --radius:14px;
+  --radius-sm:10px;
+  --radius-lg:18px;
+  --font:ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+         "Noto Sans", "Liberation Sans", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+*{box-sizing:border-box}
+html,body{height:100%}
+body.app{
+  margin:0; background:radial-gradient(1200px 700px at 25% -10%, #151823 0%, #0b0c0f 60%, #0b0c0f 100%), var(--bg);
+  color:var(--text); font-family:var(--font);
+}
+
+.topbar{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:14px 22px; border-bottom:1px solid var(--border);
+  background:linear-gradient(180deg, #0f1219 0%, #0d0f15 100%);
+  position:sticky; top:0; z-index:20;
+}
+.topbar .back{color:var(--muted); text-decoration:none}
+.topbar .back:hover{color:var(--text)}
+.server-title .name{font-weight:700; font-size:18px}
+.server-title .meta{font-size:12px; color:var(--muted)}
+.actions{display:flex; align-items:center; gap:10px}
+
+.badge{
+  display:inline-block; padding:4px 9px; border-radius:999px; font-size:12px;
+  border:1px solid var(--border); background:var(--surface)
+}
+.badge.success{background:rgba(34,197,94,.12); color:#a3ffbf; border-color:rgba(34,197,94,.25)}
+
+.btn{
+  appearance:none; border:1px solid var(--border); border-radius:10px;
+  padding:10px 14px; font-weight:600; color:var(--text);
+  background:linear-gradient(180deg, #1b2030 0%, #141927 100%);
+  box-shadow:var(--shadow); cursor:pointer; transition:filter .15s ease, transform .05s ease;
+}
+.btn:hover{filter:brightness(1.08)}
+.btn:active{transform:translateY(1px)}
+.btn.danger{background:linear-gradient(180deg, #5a1020 0%, #3a0b15 100%); border-color:#7a1630}
+.btn.ghost{background:transparent}
+.btn.small{padding:6px 10px; font-size:12px}
+
+main.grid{
+  display:grid; grid-template-columns: 360px 1fr 360px; gap:18px;
+  padding:18px 22px 28px;
+}
+.col.left{min-width:320px}
+.col.center{min-width:520px}
+.col.right{min-width:320px}
+
+.card{
+  background:linear-gradient(180deg, #12151f 0%, #0e1119 100%);
+  border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow);
+  display:flex; flex-direction:column; overflow:hidden;
+}
+.card.map-card{padding:10px}
+.card.list-card{margin-top:16px}
+.card-head{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:12px 14px; border-bottom:1px solid var(--border)
+}
+.card-title{font-weight:700}
+.card-tools{display:flex; gap:8px}
+.card-body{padding:14px}
+.card-body.no-pad{padding:0}
+.card-foot{padding:12px; border-top:1px solid var(--border); display:flex; gap:10px}
+
+.console{
+  height:420px; overflow:auto; font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  background:linear-gradient(180deg, #0c0f16 0%, #0a0d13 100%);
+  padding:10px 12px; color:#dcdfe7;
+}
+.console .line{white-space:pre-wrap; line-height:1.35}
+.console .ts{color:#6e7385}
+.console .warn{color:#fbbf24}
+.console .error{color:#f87171}
+.console a{color:#93c5fd}
+
+.console-input{
+  display:flex; gap:8px; padding:12px; border-top:1px solid var(--border); background:var(--bg-2)
+}
+.console-input input{
+  flex:1; padding:10px 12px; border-radius:10px; border:1px solid var(--border);
+  background:var(--surface); color:var(--text); outline:none;
+}
+.console-input input::placeholder{color:var(--muted)}
+
+.map-wrap{
+  position:relative; width:100%; aspect-ratio: 16 / 10; border-radius:12px;
+  background: radial-gradient(120% 100% at 20% 0%, rgba(255,80,30,.25) 0%, rgba(255,160,30,.1) 25%, rgba(40,80,200,.08) 70%, rgba(0,0,0,.15) 100%), #0a0d13;
+  border:1px solid var(--border);
+}
+.map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
+
+.players-list{max-height:260px; overflow:auto}
+.player-row{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:12px 14px; border-bottom:1px solid var(--border);
+}
+.player-row:hover{background:rgba(255,255,255,.02); cursor:pointer}
+.player-row.active{background:rgba(225,29,72,.12); outline:1px solid rgba(225,29,72,.25)}
+.player-row .who{display:flex; gap:10px; align-items:center}
+.initial{
+  width:28px; height:28px; border-radius:50%; display:grid; place-items:center;
+  background:linear-gradient(180deg, #23283a 0%, #1b2030 100%); font-weight:700; font-size:12px
+}
+.stats{display:flex; gap:10px; align-items:center; color:var(--muted); font-size:12px}
+.dot{width:8px; height:8px; border-radius:50%}
+.health{padding:3px 8px; border-radius:8px; background:#0f172a; color:#a3ffbf; border:1px solid rgba(34,197,94,.25)}
+.ping{padding:3px 8px; border-radius:8px; background:#13151f; color:#93c5fd; border:1px solid rgba(59,130,246,.25)}
+
+.right .kv{display:grid; grid-template-columns: 100px 1fr; gap:8px; margin:10px 0}
+.right .kv .k{color:var(--muted)}
+.right .actions{display:flex; gap:10px}

--- a/frontend/assets/js/panel-shell.js
+++ b/frontend/assets/js/panel-shell.js
@@ -1,0 +1,58 @@
+// Simple event bus contracts used by modules:
+// window.dispatchEvent(new CustomEvent('player:selected', { detail: { player, teamKey } }))
+// window.dispatchEvent(new CustomEvent('team:clear'))
+// window.dispatchEvent(new CustomEvent('players:list', { detail: { players } }))
+
+(() => {
+  const infoTitle = document.getElementById('info-title');
+  const infoContent = document.getElementById('info-content');
+  const playerCount = document.getElementById('player-count');
+  const showAllBtn = document.getElementById('show-all');
+
+  // When map or list selects a player → show Player Info panel
+  window.addEventListener('player:selected', (ev) => {
+    const { player } = ev.detail || {};
+    if (!player) return;
+    infoTitle.textContent = 'Player Info';
+    infoContent.innerHTML = `
+      <div class="kv"><div class="k">Name:</div><div>${escapeHtml(player.displayName || player.DisplayName)}</div></div>
+      <div class="kv"><div class="k">Steam ID:</div><div>${player.steamId || player.SteamID}</div></div>
+      <div class="kv"><div class="k">Health:</div><div>${Math.round(player.health ?? player.Health)}/100</div></div>
+      <div class="kv"><div class="k">Ping:</div><div>${player.ping ?? player.Ping} ms</div></div>
+      <div class="kv"><div class="k">Position:</div><div>(${Math.round(player.position?.x ?? player.Position?.x)}, ${Math.round(player.position?.z ?? player.Position?.z)})</div></div>
+    `;
+    // Optionally inject Kick/Ban controls here...
+  });
+
+  // Show server info again
+  function resetInfoToServer(){
+    infoTitle.textContent = 'Server Info';
+    infoContent.innerHTML = `<div data-module="server-info"></div>`;
+    // your module-loader will hydrate it again if it observes DOM mutations;
+    // otherwise call a tiny re-init here if needed.
+  }
+
+  window.addEventListener('team:clear', resetInfoToServer);
+
+  // Update player count & wire bottom list "Show All"
+  window.addEventListener('players:list', (ev) => {
+    const { players } = ev.detail || {};
+    if (Array.isArray(players)) playerCount.textContent = `(${players.length})`;
+  });
+
+  showAllBtn?.addEventListener('click', () => {
+    // notify map/list modules to clear filters
+    window.dispatchEvent(new CustomEvent('team:clear'));
+  });
+
+  function escapeHtml(str = '') {
+    const replacements = new Map([
+      ['&', '&amp;'],
+      ['<', '&lt;'],
+      ['>', '&gt;'],
+      ['"', '&quot;'],
+      ["'", '&#39;'],
+    ]);
+    return str.replace(/[&<>"']/g, (s) => replacements.get(s) ?? s);
+  }
+})();

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Rust Control Panel – Server</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="/assets/css/dark-theme.css" />
+  <script defer src="/assets/modules/module-loader.js"></script>
+  <script defer src="/assets/js/panel-shell.js"></script>
+</head>
+<body class="app">
+  <header class="topbar">
+    <a class="back" href="/servers">← Back to Servers</a>
+    <div class="server-title">
+      <div class="name" id="srv-name">Main PvP Server</div>
+      <div class="meta" id="srv-endpoint">192.168.1.100:28015 · <span id="srv-online">online</span></div>
+    </div>
+    <div class="actions">
+      <button class="btn ghost" id="btn-fullmap" title="Open full map">🗺 Show Full Map</button>
+      <span class="badge success" id="srv-status">online</span>
+    </div>
+  </header>
+
+  <main class="grid">
+    <!-- Left: Live Console -->
+    <section class="col left card">
+      <div class="card-head">
+        <div class="card-title">Console</div>
+      </div>
+      <div class="card-body no-pad">
+        <div class="console" data-module="live-console" data-props='{}'></div>
+      </div>
+      <div class="console-input">
+        <input type="text" id="console-cmd" placeholder="Enter console command..." />
+        <button class="btn danger" id="console-send">Send</button>
+      </div>
+    </section>
+
+    <!-- Center: Map -->
+    <section class="col center">
+      <div class="card map-card">
+        <div class="card-body no-pad">
+          <!-- Your live-map module mounts here -->
+          <div class="map-wrap" data-module="live-map" id="live-map-slot"
+               data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+      </div>
+
+      <!-- Bottom: Player list (filters the map on click) -->
+      <div class="card list-card">
+        <div class="card-head">
+          <div class="card-title">Online Players <span id="player-count" class="muted">(0)</span></div>
+          <div class="card-tools">
+            <button class="btn ghost small" id="show-all">Show All</button>
+          </div>
+        </div>
+        <div class="card-body no-pad">
+          <div class="players-list" data-module="players-list"
+               data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Right: Server/Player Info -->
+    <aside class="col right card">
+      <div class="card-head">
+        <div class="card-title" id="info-title">Server Info</div>
+      </div>
+      <div class="card-body" id="info-content">
+        <!-- Default server info module slot -->
+        <div data-module="server-info" data-props='{"serverId":"__SERVER_ID__"}'></div>
+      </div>
+      <div class="card-foot" id="info-actions">
+        <button class="btn ghost" id="btn-restart">Restart Server</button>
+        <button class="btn ghost" id="btn-saveworld">Save World</button>
+      </div>
+    </aside>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated server page shell that slots existing console, map, player list, and info modules
- introduce a dark theme stylesheet to style the server panel layout
- wire a lightweight panel script that swaps server/player info and syncs list counts via custom events

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d40be2ab208331855faa96628262c3