### PR TITLE
Revamp server cards with inline editing

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -315,22 +315,32 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 .section-actions { display: flex; gap: 10px; }
 
 .server-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
 }
 
 .server-card {
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-md);
   background: linear-gradient(160deg, rgba(37, 8, 16, 0.94) 0%, rgba(16, 2, 6, 0.88) 100%);
-  padding: 22px;
+  padding: 26px 30px;
   text-align: left;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   position: relative;
   overflow: hidden;
   box-shadow: 0 18px 36px rgba(244, 63, 94, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  width: 100%;
+}
+
+.server-card:focus-visible {
+  outline: 2px solid rgba(251, 113, 133, 0.65);
+  outline-offset: 3px;
 }
 
 .server-card::after {
@@ -345,22 +355,38 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 .server-card:hover { transform: translateY(-4px); box-shadow: 0 24px 40px rgba(244, 63, 94, 0.18); }
 .server-card:hover::after { opacity: 1; }
 .server-card.active { border-color: rgba(251, 113, 133, 0.65); box-shadow: 0 0 0 1px rgba(251, 113, 133, 0.35), 0 26px 50px rgba(244, 63, 94, 0.22); }
+.server-card.editing { border-color: rgba(251, 113, 133, 0.55); box-shadow: 0 0 0 1px rgba(251, 113, 133, 0.28), 0 24px 44px rgba(244, 63, 94, 0.2); }
+
+.server-card-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+}
 
 .server-card-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 16px;
+  flex: 1 1 280px;
 }
 
 .server-card-title h3 { font-size: 1.2rem; }
 .server-card-meta { margin-top: 4px; font-size: 0.92rem; color: var(--muted); }
 
 .server-card-stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 18px;
+  display: flex;
+  gap: 16px;
+  flex: 2 1 420px;
+  flex-wrap: wrap;
+  margin-top: 0;
+}
+
+.server-card-stats .server-stat {
+  flex: 1 1 140px;
 }
 
 .server-stat {
@@ -389,9 +415,57 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 .server-stat span { display: block; font-size: 0.8rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
 
 .server-card-foot {
-  margin-top: 18px;
-  font-size: 0.82rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
   color: var(--muted);
+  width: 100%;
+}
+
+.server-card-details {
+  flex: 1 1 280px;
+}
+
+.server-card-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.server-card-edit {
+  padding: 22px 24px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  display: grid;
+  gap: 16px;
+}
+
+.server-card-edit.hidden {
+  display: none;
+}
+
+.server-card-edit .row {
+  margin-top: 0;
+  justify-content: flex-end;
+}
+
+.server-edit-feedback {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.server-edit-feedback.success {
+  color: var(--success);
+}
+
+.server-edit-feedback.error {
+  color: var(--danger);
 }
 
 .empty-state {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,7 +62,7 @@
           <button id="btnToggleAddServer" class="ghost small">Add server</button>
           <nav id="mainNav" class="topnav hidden">
             <button id="navDashboard" type="button" class="nav-btn active">Dashboard</button>
-            <button id="navSettings" type="button" class="nav-btn">Settings</button>
+            <button id="navSettings" type="button" class="nav-btn">Profile &amp; Settings</button>
           </nav>
           <div id="userBox" class="user-box"></div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the server list into a full-width layout so each card reads more like a table row
- add inline editing controls on each server card to patch server name, endpoint, TLS, and optional password
- clarify navigation by renaming Settings links to "Profile & Settings" and improve card accessibility states

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d41db19cbc8331804f65172b691436