### PR TITLE
Fix RCON response handling

### DIFF
--- a/backend/src/rcon.js
+++ b/backend/src/rcon.js
@@ -72,8 +72,8 @@ export default class RustWebRcon extends EventEmitter {
         if (obj) {
           this.emit('message', obj);
           this._routeTyped(obj);
-          const id = obj.Identifier;
-          if (typeof id === 'number' && this.pending.has(id)) {
+          const id = Number(obj.Identifier);
+          if (Number.isFinite(id) && this.pending.has(id)) {
             const p = this.pending.get(id);
             this.pending.delete(id);
             clearTimeout(p.timeout);


### PR DESCRIPTION
## Summary
- normalize incoming WebRCON response identifiers to numbers
- resolve pending RCON commands even if the server returns identifier values as strings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d42748959483319b8d79cc3c3fc8ee