### PR TITLE
Fix server edit action and clean up profile controls

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -768,7 +768,12 @@
     editBtn.addEventListener('click', (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      toggleEdit();
+      if (!editOpen) {
+        toggleEdit(true);
+      } else {
+        toggleEdit(false);
+      }
+      ev.stopImmediatePropagation();
     });
 
     editForm.addEventListener('submit', async (ev) => {
@@ -809,7 +814,11 @@
     });
 
     card.addEventListener('click', (ev) => {
-      if (ev.target.closest('.server-card-actions') || ev.target.closest('.server-card-edit')) return;
+      const target = ev.target instanceof Element ? ev.target : null;
+      if (target && (target.closest('.server-card-actions') || target.closest('.server-card-edit'))) {
+        return;
+      }
+      if (editOpen) return;
       connectServer(server.id);
     });
 
@@ -945,19 +954,11 @@
         wrap.appendChild(document.createTextNode(' '));
         wrap.appendChild(badge);
       }
-      const profileBtn = document.createElement('button');
-      profileBtn.className = 'ghost small';
-      profileBtn.textContent = 'Profile & Settings';
-      profileBtn.onclick = () => {
-        hideWorkspace('nav');
-        switchPanel('settings');
-      };
       const btn = document.createElement('button');
       btn.className = 'ghost small';
       btn.textContent = 'Logout';
       btn.onclick = () => logout();
       userBox.appendChild(wrap);
-      userBox.appendChild(profileBtn);
       userBox.appendChild(btn);
     }
   };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,7 +62,7 @@
           <button id="btnToggleAddServer" class="ghost small">Add server</button>
           <nav id="mainNav" class="topnav hidden">
             <button id="navDashboard" type="button" class="nav-btn active">Dashboard</button>
-            <button id="navSettings" type="button" class="nav-btn">Profile &amp; Settings</button>
+            <button id="navSettings" type="button" class="nav-btn">Profile</button>
           </nav>
           <div id="userBox" class="user-box"></div>
         </div>


### PR DESCRIPTION
## Summary
- ensure the server card edit button opens the inline editor instead of redirecting to the workspace
- prevent workspace navigation while a server card is in edit mode
- rename the navigation settings button to "Profile" and remove the duplicate user-box entry

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d42d74c6e883318c0a3a5eeb8e327a