### PR TITLE
Revamp dashboard header menu and add server entry point

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -66,10 +66,8 @@ body::before {
 @media (max-width: 900px) {
   .app-shell { padding: 32px 20px 80px; }
   .app-header { flex-direction: column; align-items: stretch; }
-  .header-controls { width: 100%; justify-content: space-between; }
+  .header-controls { width: 100%; justify-content: center; }
   .topnav { width: 100%; justify-content: center; }
-  .header-actions { width: 100%; justify-content: space-between; flex-wrap: wrap; }
-  .user-box { width: 100%; justify-content: space-between; flex-wrap: wrap; }
 }
 
 h1, h2, h3, h4, h5 { margin: 0; font-weight: 600; }
@@ -191,7 +189,12 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   backdrop-filter: blur(18px);
 }
 
-.brand { display: flex; align-items: center; gap: 18px; }
+.brand {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  position: relative;
+}
 .brand-icon {
   display: grid;
   place-items: center;
@@ -202,6 +205,61 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   font-size: 1.6rem;
   box-shadow: 0 14px 28px rgba(244, 63, 94, 0.25);
 }
+
+.brand-meta { display: flex; flex-direction: column; gap: 10px; }
+
+.brand-account {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+  flex-wrap: wrap;
+}
+
+.brand-profile {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: none;
+  font-weight: 600;
+  color: var(--text);
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.brand-profile .profile-name { color: var(--accent-strong); }
+.brand-profile .chevron { font-size: 0.8rem; opacity: 0.65; }
+
+.brand-profile:hover,
+.brand-profile:focus-visible {
+  border-color: rgba(244, 63, 94, 0.45);
+  background: rgba(244, 63, 94, 0.14);
+  box-shadow: 0 10px 20px rgba(244, 63, 94, 0.22);
+}
+
+.brand-profile:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.brand-profile:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  border-color: transparent;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.brand-account.menu-open .brand-profile {
+  border-color: rgba(244, 63, 94, 0.45);
+  background: rgba(244, 63, 94, 0.2);
+  box-shadow: 0 16px 28px rgba(244, 63, 94, 0.28);
+}
+
+.brand-account .muted { font-size: 0.95rem; }
 
 .hero-points {
   list-style: none;
@@ -264,6 +322,7 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   flex: 1 1 260px;
 }
 
+
 .header-controls {
   display: flex;
   align-items: center;
@@ -321,30 +380,96 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 }
 
 .user-box {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--panel-strong);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  color: var(--muted-strong);
+  z-index: 30;
+}
+
+.user-box::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 24px;
+  width: 18px;
+  height: 18px;
+  background: inherit;
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  transform: rotate(45deg);
+  z-index: -1;
+}
+
+.user-box-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--muted-strong);
-  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.25);
+  justify-content: space-between;
+  gap: 10px;
 }
 
-.user-ident { display: flex; align-items: center; gap: 8px; }
+.user-box-header strong { font-size: 1rem; color: var(--text); }
 
-.user-box button {
-  padding: 6px 14px;
-  border-radius: 999px;
-  font-size: 0.9rem;
-}
-
-.user-box strong { font-size: 1rem; color: var(--text); }
-.user-box .badge {
-  background: rgba(244, 63, 94, 0.16);
-  border: 1px solid rgba(244, 63, 94, 0.28);
+.user-box-header .badge {
+  background: rgba(244, 63, 94, 0.18);
+  border: 1px solid rgba(244, 63, 94, 0.35);
   color: var(--accent-strong);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.user-box-actions { display: flex; flex-direction: column; gap: 8px; }
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: none;
+  font-size: 0.92rem;
+  color: var(--text);
+  text-align: left;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+}
+
+.menu-item:hover,
+.menu-item:focus-visible {
+  border-color: rgba(244, 63, 94, 0.45);
+  background: rgba(244, 63, 94, 0.2);
+  transform: translateY(-1px);
+}
+
+.menu-item.danger {
+  color: var(--danger);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.menu-item.danger:hover,
+.menu-item.danger:focus-visible {
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.24);
+}
+
+.menu-description {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin-top: -4px;
 }
 
 .dashboard {
@@ -398,6 +523,45 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   flex-direction: column;
   gap: 22px;
   width: 100%;
+}
+
+.server-card.add-server-prompt {
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  border-style: dashed;
+  border-color: rgba(244, 63, 94, 0.45);
+  background: rgba(244, 63, 94, 0.12);
+  color: var(--muted-strong);
+  box-shadow: 0 18px 36px rgba(244, 63, 94, 0.14);
+  text-align: center;
+}
+
+.server-card.add-server-prompt::after { display: none; }
+
+.server-card.add-server-prompt.open {
+  border-color: rgba(244, 63, 94, 0.75);
+  background: rgba(244, 63, 94, 0.26);
+  box-shadow: 0 26px 48px rgba(244, 63, 94, 0.24);
+}
+
+.server-card.add-server-prompt .add-icon {
+  font-size: 2rem;
+  line-height: 1;
+  color: var(--accent-strong);
+}
+
+.server-card.add-server-prompt .add-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.server-card.add-server-prompt:hover,
+.server-card.add-server-prompt:focus-visible {
+  border-color: rgba(244, 63, 94, 0.65);
+  background: rgba(244, 63, 94, 0.2);
+  box-shadow: 0 24px 42px rgba(244, 63, 94, 0.2);
 }
 
 .server-card:focus-visible {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,20 +53,22 @@
       <header class="app-header">
         <div class="brand">
           <span class="brand-icon" aria-hidden="true">🛡️</span>
-          <div>
+          <div class="brand-meta">
             <h1>Rust Admin Dashboard</h1>
-            <p class="muted">Welcome back, <span id="welcomeName">operator</span></p>
+            <div class="brand-account">
+              <span class="muted">Welcome back,</span>
+              <button id="profileMenuTrigger" type="button" class="brand-profile" aria-haspopup="true" aria-expanded="false" aria-controls="userBox">
+                <span id="welcomeName" class="profile-name">operator</span>
+                <span class="chevron" aria-hidden="true">▾</span>
+              </button>
+              <div id="userBox" class="user-box hidden" role="menu" aria-labelledby="profileMenuTrigger" aria-hidden="true"></div>
+            </div>
           </div>
         </div>
         <div class="header-controls">
           <nav id="mainNav" class="topnav hidden" aria-label="Application navigation">
             <button id="navDashboard" type="button" class="nav-btn active">Dashboard</button>
-            <button id="navSettings" type="button" class="nav-btn">Account</button>
           </nav>
-          <div class="header-actions">
-            <button id="btnToggleAddServer" class="ghost small">Add server</button>
-            <div id="userBox" class="user-box hidden"></div>
-          </div>
         </div>
       </header>
 
@@ -81,7 +83,13 @@
               <button id="btnRefreshServers" class="ghost icon" title="Refresh servers">⟳</button>
             </div>
           </div>
-          <div id="servers" class="server-grid"></div>
+          <div id="servers" class="server-grid">
+            <button id="addServerPrompt" type="button" class="server-card add-server-prompt" aria-controls="addServerCard" aria-expanded="false">
+              <span class="add-icon" aria-hidden="true">＋</span>
+              <span class="add-text">Add a server</span>
+              <span class="add-subtext muted small">Connect a Rust server to monitor it here.</span>
+            </button>
+          </div>
           <p id="serversEmpty" class="empty-state hidden">No servers added yet. Connect your first Rust server to get started.</p>
           <div id="addServerCard" class="add-server-card hidden">
             <h3>Add server</h3>


### PR DESCRIPTION
## Summary
- replace the header account button and duplicate username with a profile trigger in the brand area that opens a dropdown for account settings and logout
- restyle the header and user menu along with the new add-server prompt card to match the dashboard aesthetic
- update front-end logic to drive the profile dropdown interactions and swap the add server button for the grid-level prompt card

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d43734c16083319a9a511d23e24f91