### PR TITLE
Add live player directory with Steam profile integration

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -42,6 +42,10 @@ const MAP_CACHE_TZ_OFFSET_MINUTES = 120; // UTC+2
 const MAP_CACHE_RESET_HOUR = 20;
 const MAP_CACHE_RESET_MINUTE = 0;
 const KNOWN_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'];
+const STEAM_PROFILE_CACHE_TTL = Math.max(toInt(process.env.STEAM_PROFILE_CACHE_MS || '300000', 300000), 60000);
+const STEAM_PROFILE_REFRESH_INTERVAL = Math.max(toInt(process.env.STEAM_PROFILE_REFRESH_MS || '1800000', 1800000), 300000);
+const STEAM_PLAYTIME_REFRESH_INTERVAL = Math.max(toInt(process.env.STEAM_PLAYTIME_REFRESH_MS || '21600000', 21600000), 3600000);
+const RUST_STEAM_APP_ID = 252490;
 
 let lastGlobalMapCacheReset = null;
 
@@ -57,6 +61,7 @@ const auth = authMiddleware(JWT_SECRET);
 const rconBindings = new Map();
 const statusMap = new Map();
 const serverInfoCache = new Map();
+const steamProfileCache = new Map();
 let monitoring = false;
 let monitorTimer = null;
 
@@ -212,6 +217,194 @@ function parsePlayerListMessage(message) {
     teamId: Number(entry.TeamId ?? entry.teamId ?? 0) || 0,
     networkId: Number(entry.NetworkId ?? entry.networkId ?? 0) || null
   }));
+}
+
+function parseDateLike(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) return null;
+  return new Date(ts);
+}
+
+function normaliseDbPlayer(row) {
+  if (!row) return null;
+  const toNumber = (val) => {
+    if (val === null || typeof val === 'undefined') return null;
+    const num = Number(val);
+    return Number.isFinite(num) ? num : null;
+  };
+  const toBoolInt = (val) => (val ? 1 : 0);
+  const toIso = (val) => {
+    const date = parseDateLike(val);
+    return date ? date.toISOString() : null;
+  };
+  return {
+    steamid: row.steamid || row.SteamID || '',
+    persona: row.persona || null,
+    avatar: row.avatar || null,
+    country: row.country || null,
+    profileurl: row.profileurl || null,
+    vac_banned: toBoolInt(row.vac_banned),
+    game_bans: toNumber(row.game_bans) ?? 0,
+    last_ban_days: toNumber(row.last_ban_days),
+    visibility: toNumber(row.visibility),
+    rust_playtime_minutes: toNumber(row.rust_playtime_minutes),
+    playtime_updated_at: toIso(row.playtime_updated_at || row.playtimeUpdatedAt),
+    updated_at: toIso(row.updated_at || row.updatedAt)
+  };
+}
+
+function getCachedSteamProfile(steamid) {
+  const key = String(steamid || '').trim();
+  if (!key) return null;
+  const entry = steamProfileCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > STEAM_PROFILE_CACHE_TTL) {
+    steamProfileCache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCachedSteamProfile(steamid, data) {
+  const key = String(steamid || '').trim();
+  if (!key || !data) return;
+  steamProfileCache.set(key, { data, timestamp: Date.now() });
+}
+
+function shouldRefreshProfile(profile, now = Date.now()) {
+  const updated = parseDateLike(profile?.updated_at);
+  if (!updated) return true;
+  return now - updated.getTime() > STEAM_PROFILE_REFRESH_INTERVAL;
+}
+
+function shouldRefreshPlaytime(profile, now = Date.now()) {
+  const updated = parseDateLike(profile?.playtime_updated_at);
+  if (!updated) return true;
+  return now - updated.getTime() > STEAM_PLAYTIME_REFRESH_INTERVAL;
+}
+
+function extractEndpoint(address) {
+  if (typeof address !== 'string' || address.length === 0) {
+    return { ip: null, port: null };
+  }
+  const [ipPart, portPart] = address.split(':');
+  const ip = ipPart?.trim() || null;
+  const portNum = parseInt(portPart, 10);
+  return { ip, port: Number.isFinite(portNum) ? portNum : null };
+}
+
+function formatSteamProfilePayload(profile) {
+  if (!profile) return null;
+  const toNumber = (val) => {
+    if (val === null || typeof val === 'undefined') return null;
+    const num = Number(val);
+    return Number.isFinite(num) ? num : null;
+  };
+  const minutes = toNumber(profile.rust_playtime_minutes);
+  return {
+    persona: profile.persona || null,
+    avatar: profile.avatar || null,
+    country: profile.country || null,
+    profileUrl: profile.profileurl || null,
+    vacBanned: !!(Number(profile.vac_banned) || profile.vac_banned === true),
+    gameBans: Number(profile.game_bans) || 0,
+    daysSinceLastBan: toNumber(profile.last_ban_days),
+    visibility: toNumber(profile.visibility),
+    rustPlaytimeMinutes: minutes,
+    updatedAt: profile.updated_at || null,
+    playtimeUpdatedAt: profile.playtime_updated_at || null
+  };
+}
+
+async function fetchRustPlaytimeMinutes(steamid, key) {
+  const url = `https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=${encodeURIComponent(key)}&steamid=${encodeURIComponent(steamid)}&include_appinfo=0&include_played_free_games=1&appids_filter%5B0%5D=${RUST_STEAM_APP_ID}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    if (res.status === 403 || res.status === 401) return null;
+    throw new Error('steam_playtime_error');
+  }
+  const data = await res.json();
+  const games = data?.response?.games;
+  if (!Array.isArray(games)) return null;
+  const rust = games.find((g) => Number(g.appid) === RUST_STEAM_APP_ID);
+  if (!rust) return 0;
+  const minutes = Number(rust.playtime_forever);
+  return Number.isFinite(minutes) ? minutes : null;
+}
+
+async function resolveSteamProfiles(steamids) {
+  const ids = [...new Set((steamids || []).map((id) => String(id || '').trim()).filter(Boolean))];
+  const profileMap = new Map();
+  if (ids.length === 0) return profileMap;
+  if (typeof db.getPlayersBySteamIds === 'function') {
+    try {
+      const rows = await db.getPlayersBySteamIds(ids);
+      for (const row of rows) {
+        const normalized = normaliseDbPlayer(row);
+        if (normalized?.steamid) profileMap.set(normalized.steamid, normalized);
+      }
+    } catch (err) {
+      console.warn('Failed to load stored player profiles', err);
+    }
+  }
+  const now = Date.now();
+  const toFetch = [];
+  for (const steamid of ids) {
+    const cached = getCachedSteamProfile(steamid);
+    if (cached) {
+      profileMap.set(steamid, cached);
+      continue;
+    }
+    const existing = profileMap.get(steamid);
+    if (!existing || shouldRefreshProfile(existing, now) || shouldRefreshPlaytime(existing, now)) {
+      toFetch.push(steamid);
+    }
+  }
+  if (toFetch.length > 0 && process.env.STEAM_API_KEY) {
+    try {
+      const fetched = await fetchSteamProfiles(toFetch, process.env.STEAM_API_KEY, { includePlaytime: true });
+      const nowIso = new Date().toISOString();
+      await Promise.all(fetched.map(async (profile) => {
+        const normalized = {
+          ...profile,
+          updated_at: nowIso,
+          playtime_updated_at: profile.playtime_updated_at || nowIso
+        };
+        profileMap.set(profile.steamid, normalized);
+        setCachedSteamProfile(profile.steamid, normalized);
+        await db.upsertPlayer({ ...profile, playtime_updated_at: normalized.playtime_updated_at });
+      }));
+    } catch (err) {
+      console.warn('Steam profile enrichment failed', err);
+    }
+  }
+  return profileMap;
+}
+
+async function enrichLivePlayers(players) {
+  if (!Array.isArray(players) || players.length === 0) return [];
+  try {
+    const steamIds = players.map((p) => p?.steamId || '').filter(Boolean);
+    const profiles = await resolveSteamProfiles(steamIds);
+    return players.map((player) => {
+      const endpoint = extractEndpoint(player.address);
+      const profile = profiles.get(player.steamId) || null;
+      return {
+        ...player,
+        ip: endpoint.ip,
+        port: endpoint.port,
+        steamProfile: formatSteamProfilePayload(profile)
+      };
+    });
+  } catch (err) {
+    console.warn('Failed to enrich live players', err);
+    return players.map((player) => {
+      const endpoint = extractEndpoint(player.address);
+      return { ...player, ip: endpoint.ip, port: endpoint.port, steamProfile: null };
+    });
+  }
 }
 
 function getCachedServerInfo(id) {
@@ -795,7 +988,8 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       console.error('playerlist command failed', err);
       return res.status(502).json({ error: 'playerlist_failed' });
     }
-    const players = parsePlayerListMessage(playerPayload);
+    let players = parsePlayerListMessage(playerPayload);
+    players = await enrichLivePlayers(players);
     const now = new Date();
     let mapRecord = await db.getServerMap(id);
     if (mapRecord && shouldResetMapRecord(mapRecord, now)) {
@@ -998,22 +1192,71 @@ app.post('/api/players/:steamid/event', auth, async (req, res) => {
   }
 });
 
-async function fetchSteamProfiles(steamids, key) {
-  const ids = steamids.slice(0, 100).join(',');
-  const url = `https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key=${encodeURIComponent(key)}&steamids=${encodeURIComponent(ids)}`;
+async function fetchSteamProfiles(steamids, key, { includePlaytime = false } = {}) {
+  const unique = [...new Set((steamids || []).map((id) => String(id || '').trim()).filter(Boolean))];
+  if (unique.length === 0) return [];
+  const ids = unique.slice(0, 100);
+  const joined = ids.join(',');
+  const url = `https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key=${encodeURIComponent(key)}&steamids=${encodeURIComponent(joined)}`;
   const r = await fetch(url);
   if (!r.ok) throw new Error('steam_api_error');
   const j = await r.json();
   const players = j?.response?.players || [];
-  const bansUrl = `https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key=${encodeURIComponent(key)}&steamids=${encodeURIComponent(ids)}`;
+  const bansUrl = `https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key=${encodeURIComponent(key)}&steamids=${encodeURIComponent(joined)}`;
   const rb = await fetch(bansUrl);
-  let bans = {};
+  const banMap = new Map();
   if (rb.ok) {
     const jb = await rb.json();
-    for (const b of (jb?.players || [])) bans[b.SteamId] = b.VACBanned ? 1 : 0;
+    for (const b of jb?.players || []) {
+      banMap.set(String(b.SteamId), {
+        vac_banned: b.VACBanned ? 1 : 0,
+        game_bans: Number(b.NumberOfGameBans) || 0,
+        last_ban_days: Number.isFinite(Number(b.DaysSinceLastBan)) ? Number(b.DaysSinceLastBan) : null
+      });
+    }
   }
-  for (const p of players) p.vac_banned = bans[p.steamid] || 0;
-  return players;
+  const playtimeMap = new Map();
+  const nowIso = new Date().toISOString();
+  if (includePlaytime) {
+    for (const player of players) {
+      const sid = String(player?.steamid || '');
+      if (!sid) continue;
+      const visibility = Number(player.communityvisibilitystate);
+      if (visibility !== 3) {
+        playtimeMap.set(sid, null);
+        continue;
+      }
+      try {
+        const minutes = await fetchRustPlaytimeMinutes(sid, key);
+        playtimeMap.set(sid, typeof minutes === 'number' ? minutes : null);
+      } catch (err) {
+        console.warn('Steam playtime fetch failed for', sid, err);
+        playtimeMap.set(sid, null);
+      }
+    }
+  }
+  const out = [];
+  for (const player of players) {
+    const sid = String(player?.steamid || '');
+    if (!sid) continue;
+    const ban = banMap.get(sid) || {};
+    const visibility = Number.isFinite(Number(player.communityvisibilitystate)) ? Number(player.communityvisibilitystate) : null;
+    const playtime = playtimeMap.has(sid) ? playtimeMap.get(sid) : null;
+    out.push({
+      steamid: sid,
+      persona: player.personaname || null,
+      avatar: player.avatarfull || null,
+      country: player.loccountrycode || null,
+      profileurl: player.profileurl || null,
+      vac_banned: ban.vac_banned ? 1 : 0,
+      game_bans: Number(ban.game_bans) || 0,
+      last_ban_days: Number.isFinite(Number(ban.last_ban_days)) ? Number(ban.last_ban_days) : null,
+      visibility,
+      rust_playtime_minutes: typeof playtime === 'number' ? playtime : null,
+      playtime_updated_at: includePlaytime ? nowIso : null
+    });
+  }
+  return out;
 }
 
 app.post('/api/steam/sync', auth, async (req, res) => {
@@ -1021,15 +1264,21 @@ app.post('/api/steam/sync', auth, async (req, res) => {
   if (!Array.isArray(steamids) || steamids.length === 0) return res.status(400).json({ error: 'missing_steamids' });
   if (!process.env.STEAM_API_KEY) return res.status(400).json({ error: 'no_steam_api_key' });
   try {
-    const list = await fetchSteamProfiles(steamids, process.env.STEAM_API_KEY);
-    for (const p of list) {
+    const list = await fetchSteamProfiles(steamids, process.env.STEAM_API_KEY, { includePlaytime: true });
+    const nowIso = new Date().toISOString();
+    for (const profile of list) {
       await db.upsertPlayer({
-        steamid: p.steamid,
-        persona: p.personaname,
-        avatar: p.avatarfull,
-        country: p.loccountrycode || null,
-        profileurl: p.profileurl || null,
-        vac_banned: p.vac_banned || 0
+        steamid: profile.steamid,
+        persona: profile.persona,
+        avatar: profile.avatar,
+        country: profile.country,
+        profileurl: profile.profileurl,
+        vac_banned: profile.vac_banned || 0,
+        game_bans: profile.game_bans || 0,
+        last_ban_days: profile.last_ban_days ?? null,
+        visibility: profile.visibility ?? null,
+        rust_playtime_minutes: profile.rust_playtime_minutes ?? null,
+        playtime_updated_at: profile.playtime_updated_at || nowIso
       });
     }
     res.json({ updated: list.length });

--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -71,6 +71,8 @@ main.grid{
 }
 .card.map-card{padding:10px}
 .card.list-card{margin-top:16px}
+.players-card{grid-column:1/-1;margin-top:18px}
+.players-card .card-body{padding:0}
 .card-head{
   display:flex; align-items:center; justify-content:space-between;
   padding:12px 14px; border-bottom:1px solid var(--border)
@@ -109,6 +111,31 @@ main.grid{
 .map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
 
 .players-list{max-height:260px; overflow:auto}
+.live-players-list{display:flex; flex-direction:column}
+.live-player-row{display:flex; gap:16px; padding:18px 22px; border-bottom:1px solid var(--border); transition:background .15s ease, border-color .15s ease; align-items:flex-start}
+.live-player-row:last-child{border-bottom:none}
+.live-player-row:hover{background:rgba(255,255,255,.03); cursor:pointer}
+.live-player-row.active{background:rgba(225,29,72,.12); border-left:4px solid rgba(225,29,72,.55)}
+.live-player-identity{display:flex; gap:16px; align-items:center; flex:1}
+.live-player-avatar{width:52px; height:52px; border-radius:14px; overflow:hidden; background:var(--surface-2); display:grid; place-items:center; font-weight:700; color:var(--muted); text-transform:uppercase}
+.live-player-avatar img{width:100%; height:100%; object-fit:cover}
+.live-player-meta{display:flex; flex-direction:column; gap:4px}
+.live-player-name{font-weight:600; display:flex; gap:8px; align-items:center}
+.live-player-name a{color:inherit; text-decoration:none}
+.live-player-name a:hover{text-decoration:underline}
+.live-player-sub{font-size:12px; color:var(--muted)}
+.live-player-hours{color:var(--muted)}
+.live-player-details{display:flex; flex-direction:column; gap:10px; align-items:flex-end; min-width:220px}
+.live-player-stats{display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end}
+.live-player-stats .stat{font-size:12px; padding:4px 10px; border-radius:999px; border:1px solid rgba(148,163,184,.25); background:rgba(15,23,42,.45); color:var(--muted)}
+.live-player-stats .stat.health{color:#a3ffbf; border-color:rgba(34,197,94,.35); background:rgba(34,197,94,.18)}
+.live-player-stats .stat.ping{color:#93c5fd; border-color:rgba(59,130,246,.35); background:rgba(59,130,246,.18)}
+.live-player-stats .stat.violation{color:#fca5a5; border-color:rgba(239,68,68,.4); background:rgba(239,68,68,.18)}
+.live-player-badges{display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end}
+.badge.vac{background:rgba(239,68,68,.2); color:#fecaca; border-color:rgba(239,68,68,.45)}
+.badge.gameban{background:rgba(249,115,22,.2); color:#fed7aa; border-color:rgba(249,115,22,.45)}
+.badge.country{background:rgba(59,130,246,.2); color:#bfdbfe; border-color:rgba(59,130,246,.45)}
+.badge.warn{background:rgba(245,158,11,.18); color:#fde68a; border-color:rgba(245,158,11,.4)}
 .player-row{
   display:flex; align-items:center; justify-content:space-between;
   padding:12px 14px; border-bottom:1px solid var(--border);

--- a/frontend/assets/modules/live-players.js
+++ b/frontend/assets/modules/live-players.js
@@ -1,0 +1,291 @@
+(function(){
+  if (typeof window.registerModule !== 'function') return;
+
+  function formatDuration(seconds) {
+    if (!Number.isFinite(seconds)) return '—';
+    const total = Math.max(0, Math.floor(seconds));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m`;
+    return `${total % 60}s`;
+  }
+
+  function formatPlaytime(minutes) {
+    if (!Number.isFinite(minutes)) return 'Profile private';
+    if (minutes <= 0) return 'No recorded hours';
+    const hours = minutes / 60;
+    if (hours >= 100) return `${Math.round(hours)} h`;
+    return `${hours.toFixed(1)} h`;
+  }
+
+  function avatarInitial(name = '') {
+    const trimmed = name.trim();
+    if (!trimmed) return '?';
+    const codePoint = trimmed.codePointAt(0);
+    return String.fromCodePoint(codePoint).toUpperCase();
+  }
+
+  window.registerModule({
+    id: 'live-players',
+    title: 'Connected Players',
+    order: 30,
+    setup(ctx){
+      ctx.root?.classList.add('module-card', 'live-players-card');
+
+      const message = document.createElement('p');
+      message.className = 'module-message hidden';
+      ctx.body?.appendChild(message);
+
+      const list = document.createElement('div');
+      list.className = 'live-players-list';
+      ctx.body?.appendChild(list);
+
+      let clearBtn = null;
+      let clearHandler = null;
+
+      function bindClearButton() {
+        clearBtn = document.getElementById('show-all');
+        if (!clearBtn) return;
+        if (clearHandler) clearBtn.removeEventListener('click', clearHandler);
+        clearHandler = () => {
+          ctx.emit?.('live-players:focus', { steamId: null });
+        };
+        clearBtn.addEventListener('click', clearHandler);
+      }
+
+      bindClearButton();
+
+      const state = {
+        serverId: null,
+        players: [],
+        selected: null
+      };
+
+      function setMessage(text, variant = 'info') {
+        if (!message) return;
+        message.textContent = text;
+        message.dataset.variant = variant;
+        message.classList.remove('hidden');
+      }
+
+      function clearMessage() {
+        if (!message) return;
+        message.textContent = '';
+        message.classList.add('hidden');
+        message.removeAttribute('data-variant');
+      }
+
+      function updateCount() {
+        const badge = document.getElementById('player-count');
+        if (!badge) return;
+        badge.textContent = `(${state.players.length})`;
+      }
+
+      function highlightRows() {
+        const rows = list.querySelectorAll('.live-player-row');
+        rows.forEach((row) => {
+          if (!state.selected) {
+            row.classList.remove('active');
+            return;
+          }
+          if (row.dataset.steamid === state.selected) row.classList.add('active');
+          else row.classList.remove('active');
+        });
+      }
+
+      function render() {
+        updateCount();
+        list.innerHTML = '';
+        if (!state.serverId) {
+          setMessage('Connect to a server to view connected players.');
+          return;
+        }
+        if (state.players.length === 0) {
+          setMessage('No players connected right now.');
+          return;
+        }
+        clearMessage();
+        for (const player of state.players) {
+          const row = document.createElement('article');
+          row.className = 'live-player-row';
+          row.dataset.steamid = player.steamId || '';
+
+          const identity = document.createElement('div');
+          identity.className = 'live-player-identity';
+
+          const avatarWrap = document.createElement('div');
+          avatarWrap.className = 'live-player-avatar';
+          const profile = player.steamProfile || {};
+          if (profile.avatar) {
+            const img = document.createElement('img');
+            img.src = profile.avatar;
+            img.alt = `${player.displayName || profile.persona || player.steamId || 'Player'} avatar`;
+            img.loading = 'lazy';
+            avatarWrap.appendChild(img);
+          } else {
+            avatarWrap.classList.add('placeholder');
+            avatarWrap.textContent = avatarInitial(player.displayName || profile.persona || player.steamId || '');
+          }
+
+          const meta = document.createElement('div');
+          meta.className = 'live-player-meta';
+          const nameRow = document.createElement('div');
+          nameRow.className = 'live-player-name';
+          const displayName = player.displayName || profile.persona || player.steamId || 'Unknown player';
+          if (profile.profileUrl) {
+            const link = document.createElement('a');
+            link.href = profile.profileUrl;
+            link.target = '_blank';
+            link.rel = 'noreferrer';
+            link.textContent = displayName;
+            nameRow.appendChild(link);
+          } else {
+            nameRow.textContent = displayName;
+          }
+          if (profile.country) {
+            const badge = document.createElement('span');
+            badge.className = 'badge country';
+            badge.textContent = profile.country;
+            nameRow.appendChild(badge);
+          }
+          meta.appendChild(nameRow);
+
+          const steamIdLine = document.createElement('div');
+          steamIdLine.className = 'live-player-sub';
+          steamIdLine.textContent = player.steamId || '—';
+          meta.appendChild(steamIdLine);
+
+          const ipLine = document.createElement('div');
+          ipLine.className = 'live-player-sub';
+          ipLine.textContent = player.ip ? `${player.ip}${player.port ? ':' + player.port : ''}` : 'IP hidden';
+          meta.appendChild(ipLine);
+
+          const connectedLine = document.createElement('div');
+          connectedLine.className = 'live-player-sub';
+          connectedLine.textContent = `Connected ${formatDuration(player.connectedSeconds)}`;
+          meta.appendChild(connectedLine);
+
+          const playtimeLine = document.createElement('div');
+          playtimeLine.className = 'live-player-sub live-player-hours';
+          playtimeLine.textContent = `Rust playtime · ${formatPlaytime(profile.rustPlaytimeMinutes)}`;
+          meta.appendChild(playtimeLine);
+
+          identity.appendChild(avatarWrap);
+          identity.appendChild(meta);
+          row.appendChild(identity);
+
+          const details = document.createElement('div');
+          details.className = 'live-player-details';
+
+          const stats = document.createElement('div');
+          stats.className = 'live-player-stats';
+          const health = document.createElement('span');
+          health.className = 'stat health';
+          health.textContent = `${Math.round(player.health ?? 0)} hp`;
+          stats.appendChild(health);
+          const ping = document.createElement('span');
+          ping.className = 'stat ping';
+          ping.textContent = `${Math.round(player.ping ?? 0)} ms`;
+          stats.appendChild(ping);
+          const violation = Number(player.violationLevel ?? player.ViolationLevel ?? 0);
+          if (violation > 0) {
+            const vio = document.createElement('span');
+            vio.className = 'stat violation';
+            vio.textContent = `Violation ${violation}`;
+            stats.appendChild(vio);
+          }
+          details.appendChild(stats);
+
+          const badges = document.createElement('div');
+          badges.className = 'live-player-badges';
+          if (profile.vacBanned) {
+            const vac = document.createElement('span');
+            vac.className = 'badge vac';
+            vac.textContent = 'VAC ban';
+            badges.appendChild(vac);
+          }
+          if (Number(profile.gameBans) > 0) {
+            const gameBan = document.createElement('span');
+            gameBan.className = 'badge gameban';
+            gameBan.textContent = `${profile.gameBans} game ban${profile.gameBans > 1 ? 's' : ''}`;
+            badges.appendChild(gameBan);
+          }
+          if (Number.isFinite(profile.daysSinceLastBan)) {
+            const last = document.createElement('span');
+            last.className = 'badge warn';
+            last.textContent = `${profile.daysSinceLastBan}d since last ban`;
+            badges.appendChild(last);
+          }
+          if (badges.childElementCount > 0) details.appendChild(badges);
+
+          row.appendChild(details);
+
+          row.addEventListener('click', () => {
+            state.selected = player.steamId || null;
+            highlightRows();
+            ctx.emit?.('live-players:focus', { steamId: player.steamId, player });
+            window.dispatchEvent(new CustomEvent('player:selected', { detail: { player } }));
+          });
+
+          list.appendChild(row);
+        }
+        highlightRows();
+      }
+
+      const offConnect = ctx.on?.('server:connected', ({ serverId }) => {
+        state.serverId = serverId;
+        setMessage('Loading players…');
+      });
+
+      const offDisconnect = ctx.on?.('server:disconnected', ({ serverId }) => {
+        if (state.serverId && serverId === state.serverId) {
+          state.serverId = null;
+          state.players = [];
+          state.selected = null;
+          list.innerHTML = '';
+          setMessage('Connect to a server to view connected players.');
+          updateCount();
+        }
+      });
+
+      const offLogout = ctx.on?.('auth:logout', () => {
+        state.serverId = null;
+        state.players = [];
+        state.selected = null;
+        list.innerHTML = '';
+        setMessage('Sign in to view connected players.');
+        updateCount();
+      });
+
+      const offData = ctx.on?.('live-players:data', ({ players, serverId }) => {
+        if (Number.isFinite(Number(serverId)) && state.serverId && Number(serverId) !== Number(state.serverId)) return;
+        state.players = Array.isArray(players) ? players : [];
+        render();
+      });
+
+      const offHighlight = ctx.on?.('live-players:highlight', ({ steamId }) => {
+        state.selected = steamId || null;
+        highlightRows();
+      });
+
+      const onTeamClear = () => {
+        state.selected = null;
+        highlightRows();
+      };
+      window.addEventListener('team:clear', onTeamClear);
+
+      ctx.onCleanup?.(() => offConnect?.());
+      ctx.onCleanup?.(() => offDisconnect?.());
+      ctx.onCleanup?.(() => offLogout?.());
+      ctx.onCleanup?.(() => offData?.());
+      ctx.onCleanup?.(() => offHighlight?.());
+      ctx.onCleanup?.(() => {
+        if (clearBtn && clearHandler) clearBtn.removeEventListener('click', clearHandler);
+      });
+      ctx.onCleanup?.(() => window.removeEventListener('team:clear', onTeamClear));
+
+      setMessage('Connect to a server to view connected players.');
+    }
+  });
+})();

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Rust Control Panel – Server</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <link rel="stylesheet" href="/assets/css/dark-theme.css" />
-  <script defer src="/assets/modules/module-loader.js"></script>
-  <script defer src="/assets/js/panel-shell.js"></script>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rust Control Panel – Server</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/dark-theme.css" />
+    <script defer src="/assets/modules/module-loader.js"></script>
+    <script defer src="/assets/modules/map.js"></script>
+    <script defer src="/assets/modules/live-players.js"></script>
+    <script defer src="/assets/js/panel-shell.js"></script>
+  </head>
 <body class="app">
   <header class="topbar">
     <a class="back" href="/servers">← Back to Servers</a>
@@ -46,19 +48,6 @@
         </div>
       </div>
 
-      <!-- Bottom: Player list (filters the map on click) -->
-      <div class="card list-card">
-        <div class="card-head">
-          <div class="card-title">Online Players <span id="player-count" class="muted">(0)</span></div>
-          <div class="card-tools">
-            <button class="btn ghost small" id="show-all">Show All</button>
-          </div>
-        </div>
-        <div class="card-body no-pad">
-          <div class="players-list" data-module="players-list"
-               data-props='{"serverId":"__SERVER_ID__"}'></div>
-        </div>
-      </div>
     </section>
 
     <!-- Right: Server/Player Info -->
@@ -75,6 +64,19 @@
         <button class="btn ghost" id="btn-saveworld">Save World</button>
       </div>
     </aside>
+
+    <section class="card players-card">
+      <div class="card-head">
+        <div class="card-title">Connected Players <span id="player-count" class="muted">(0)</span></div>
+        <div class="card-tools">
+          <button class="btn ghost small" id="show-all">Show everyone</button>
+        </div>
+      </div>
+      <div class="card-body no-pad">
+        <div class="live-players-board" data-module="live-players"
+             data-props='{"serverId":"__SERVER_ID__"}'></div>
+      </div>
+    </section>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend player persistence to store Steam bans and Rust playtime metadata and expose it via the live-map API
- enrich live player polling with cached Steam profile lookups and playtime fetches while keeping sync endpoints up to date
- replace the compact player list with a full-width connected players directory, refreshed styling, and richer player details in the info pane

## Testing
- node --check backend/src/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d456e3bc9483319ef35dc706d42b56