### PR TITLE
Handle plain string console events

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -505,10 +505,14 @@
       if (status && typeof status.id !== 'undefined') updateServerStatus(status.id, status);
     });
     socket.on('console', (msg) => {
-      if (msg?.Message) {
-        ui.log(msg.Message.trim());
-        moduleBus.emit('console:message', { serverId: state.currentServerId, message: msg });
+      const raw = typeof msg === 'string'
+        ? msg
+        : (msg?.Message ?? msg?.message ?? '');
+      const text = typeof raw === 'string' ? raw.trim() : '';
+      if (text) {
+        ui.log(text);
       }
+      moduleBus.emit('console:message', { serverId: state.currentServerId, message: msg });
     });
     socket.on('error', (err) => {
       const message = typeof err === 'string' ? err : err?.message || JSON.stringify(err);


### PR DESCRIPTION
## Summary
- ensure the dashboard console handler logs plain string websocket messages
- emit console:message events for all console payloads so the live console module updates consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d46744421c833196628ad7bfb96717