### PR TITLE
Log player counts for monitoring snapshots

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -818,6 +818,18 @@ rconEventBus.on('monitor_status', (serverId, payload) => {
     latency,
     details
   });
+  if (typeof db.recordServerPlayerCount === 'function' && details?.players?.online != null) {
+    const snapshot = {
+      server_id: id,
+      player_count: details.players.online,
+      max_players: Number.isFinite(details.players.max) ? details.players.max : null,
+      queued: Number.isFinite(details.queued) ? details.queued : null,
+      sleepers: Number.isFinite(details.sleepers) ? details.sleepers : null
+    };
+    db.recordServerPlayerCount(snapshot).catch((err) => {
+      console.warn('Failed to record player count snapshot', err);
+    });
+  }
 });
 
 rconEventBus.on('monitor_error', (serverId, error) => {


### PR DESCRIPTION
## Summary
- add a server_player_counts table for both SQLite and MySQL backends to store timestamped player totals
- expose helpers to persist player count snapshots alongside optional max, queued, and sleeper values
- record player counts from monitor status polling so historical data is captured automatically

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d46849eca483319d6bff63f29d67e2