### PR TITLE
Track live players through monitoring

### DIFF
--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -65,7 +65,14 @@
           const meta = document.createElement('div');
           meta.className = 'muted small';
           const lastSeen = formatTimestamp(p.last_seen);
-          meta.textContent = lastSeen ? `${p.steamid} · Last seen ${lastSeen}` : p.steamid;
+          const parts = [];
+          parts.push(p.steamid || '—');
+          if (p.last_ip) {
+            const endpoint = p.last_port ? `${p.last_ip}:${p.last_port}` : p.last_ip;
+            parts.push(endpoint);
+          }
+          if (lastSeen) parts.push(`Last seen ${lastSeen}`);
+          meta.textContent = parts.join(' · ');
           left.appendChild(meta);
           const right = document.createElement('div');
           right.className = 'server-actions';


### PR DESCRIPTION
## Summary
- run the playerlist command on every monitor tick to persist live player snapshots and push status updates
- extend both SQLite and MySQL server_players storage with last_ip/last_port columns and write the new data
- surface the stored endpoint in the players directory UI so operator lists stay up to date

## Testing
- node --check backend/src/index.js
- node --check backend/src/rcon.js
- node --check frontend/assets/modules/players.js

------
https://chatgpt.com/codex/tasks/task_e_68d4de6c6a688331a26f03c5448b944d