### PR TITLE
Refactor server page into tabbed menu layout

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -64,6 +64,65 @@ main.grid{
 .col.center{min-width:520px}
 .col.right{min-width:320px}
 
+.server-panel{
+  padding:22px 24px 36px;
+  display:flex; flex-direction:column; gap:24px;
+}
+
+.server-menu{
+  display:flex; gap:12px; flex-wrap:wrap;
+}
+
+.menu-tab{
+  appearance:none; border:1px solid var(--border); border-radius:999px;
+  padding:10px 18px; font-weight:600; font-size:14px;
+  background:linear-gradient(180deg, #1b2030 0%, #131722 100%);
+  color:var(--muted); cursor:pointer; transition:filter .15s ease, transform .05s ease;
+}
+
+.menu-tab:hover{filter:brightness(1.1)}
+.menu-tab:active{transform:translateY(1px)}
+.menu-tab.active{
+  background:rgba(225,29,72,.18); color:#fda4af;
+  border-color:rgba(225,29,72,.45); box-shadow:inset 0 0 0 1px rgba(225,29,72,.45);
+}
+
+.view-panel{display:none; flex-direction:column; gap:22px}
+.view-panel.active{display:flex}
+.card.full-width{width:100%}
+.players-strip{padding:0 18px 18px}
+.players-strip .module-message{padding:28px; text-align:center; color:var(--muted)}
+.players-strip .live-players-list{
+  display:grid; gap:16px; padding:18px 0 0;
+  grid-template-columns:repeat(auto-fill, minmax(280px, 1fr));
+}
+.players-strip .live-player-row{
+  border:1px solid var(--border); border-radius:16px;
+  padding:18px; display:flex; flex-direction:column; gap:16px;
+  background:rgba(12,15,24,.75); border-bottom:none;
+}
+.players-strip .live-player-row:hover{background:rgba(225,29,72,.12)}
+.players-strip .live-player-details{align-items:flex-start}
+
+.players-directory{padding:0}
+.players-directory .module-message{padding:24px; text-align:center}
+.player-directory{
+  list-style:none; margin:0; padding:0; display:flex; flex-direction:column;
+}
+.player-directory li{
+  display:flex; justify-content:space-between; gap:18px; align-items:flex-start;
+  padding:16px 18px; border-bottom:1px solid var(--border);
+  background:rgba(12,15,23,.6);
+}
+.player-directory li:nth-child(even){background:rgba(255,255,255,.02)}
+.player-directory strong{font-weight:600}
+.player-directory .muted{color:var(--muted)}
+.player-directory .small{font-size:12px}
+.player-directory .server-actions{display:flex; gap:10px; flex-wrap:wrap}
+
+.muted{color:var(--muted)}
+.small{font-size:12px}
+
 .card{
   background:linear-gradient(180deg, #12151f 0%, #0e1119 100%);
   border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow);

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -9,6 +9,7 @@
     <script defer src="/assets/modules/live-console.js"></script>
     <script defer src="/assets/modules/map.js"></script>
     <script defer src="/assets/modules/live-players.js"></script>
+    <script defer src="/assets/modules/players.js"></script>
     <script defer src="/assets/js/panel-shell.js"></script>
   </head>
 <body class="app">
@@ -24,66 +25,102 @@
     </div>
   </header>
 
-  <main class="grid">
-    <!-- Left: Live Console -->
-    <section class="col left card">
-      <div class="card-head">
-        <div class="card-title">Console</div>
+  <main class="server-panel">
+    <nav class="server-menu" aria-label="Server sections">
+      <button class="menu-tab active" type="button" data-target="players">Players</button>
+      <button class="menu-tab" type="button" data-target="map">Map</button>
+      <button class="menu-tab" type="button" data-target="console">Console</button>
+      <button class="menu-tab" type="button" data-target="dashboard">Dashboard</button>
+    </nav>
+
+    <section class="view-panel active" data-view="players">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Current Players <span id="player-count" class="muted">(0)</span></div>
+          <div class="card-tools">
+            <button class="btn ghost small" id="show-all">Show everyone</button>
+          </div>
+        </div>
+        <div class="card-body no-pad players-strip">
+          <div class="live-players-board" data-module="live-players"
+               data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
       </div>
-      <div class="card-body no-pad">
-        <div class="console" data-module="live-console" data-props='{}'></div>
-      </div>
-      <div class="console-input">
-        <input type="text" id="console-cmd" placeholder="Enter console command..." />
-        <button class="btn danger" id="console-send">Send</button>
+
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">All Players</div>
+        </div>
+        <div class="card-body players-directory" data-module="players-directory"
+             data-props='{"serverId":"__SERVER_ID__"}'></div>
       </div>
     </section>
 
-    <!-- Center: Player map -->
-    <section class="col center">
-      <div class="card map-card player-map-card">
+    <section class="view-panel" data-view="map">
+      <div class="card full-width map-card">
         <div class="card-head">
-          <div class="card-title">Player Map</div>
-          <nav class="subnav" aria-label="Player views">
-            <button type="button" class="subnav-btn active" id="player-view-all">All Players</button>
-          </nav>
+          <div class="card-title">Live Map</div>
         </div>
         <div class="card-body no-pad">
-          <!-- Your live-map module mounts here -->
           <div class="map-wrap" data-module="live-map" id="live-map-slot"
                data-props='{"serverId":"__SERVER_ID__"}'></div>
         </div>
-        <div class="card-foot player-list-foot">
-          <div class="player-list-head">
-            <div class="player-list-title">All Players <span id="player-count" class="muted">(0)</span></div>
-            <div class="card-tools">
-              <button class="btn ghost small" id="show-all">Show everyone</button>
-            </div>
-          </div>
-          <div class="player-list-body">
-            <div class="live-players-board" data-module="live-players"
-                 data-props='{"serverId":"__SERVER_ID__"}'></div>
-          </div>
-        </div>
       </div>
-
     </section>
 
-    <!-- Right: Server/Player Info -->
-    <aside class="col right card">
-      <div class="card-head">
-        <div class="card-title" id="info-title">Server Info</div>
+    <section class="view-panel" data-view="console">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Console</div>
+        </div>
+        <div class="card-body no-pad">
+          <div class="console" data-module="live-console" data-props='{}'></div>
+        </div>
+        <div class="console-input">
+          <input type="text" id="console-cmd" placeholder="Enter console command..." />
+          <button class="btn danger" id="console-send">Send</button>
+        </div>
       </div>
-      <div class="card-body" id="info-content">
-        <!-- Default server info module slot -->
-        <div data-module="server-info" data-props='{"serverId":"__SERVER_ID__"}'></div>
-      </div>
-      <div class="card-foot" id="info-actions">
-        <button class="btn ghost" id="btn-restart">Restart Server</button>
-        <button class="btn ghost" id="btn-saveworld">Save World</button>
-      </div>
-    </aside>
+    </section>
 
+    <section class="view-panel" data-view="dashboard">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title" id="info-title">Server Info</div>
+        </div>
+        <div class="card-body" id="info-content">
+          <div data-module="server-info" data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+        <div class="card-foot" id="info-actions">
+          <button class="btn ghost" id="btn-restart">Restart Server</button>
+          <button class="btn ghost" id="btn-saveworld">Save World</button>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const tabs = Array.from(document.querySelectorAll('.menu-tab'));
+      const views = Array.from(document.querySelectorAll('.view-panel'));
+
+      function activate(target) {
+        tabs.forEach((btn) => {
+          const isActive = btn.dataset.target === target;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+        views.forEach((panel) => {
+          panel.classList.toggle('active', panel.dataset.view === target);
+        });
+      }
+
+      tabs.forEach((btn) => {
+        btn.addEventListener('click', () => activate(btn.dataset.target));
+      });
+
+      activate('players');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the server overview grid with a tabbed navigation for players, map, console, and dashboard views
- add dedicated cards for live players, the cached player directory, live map, console, and server info within the new layout
- extend the dark theme stylesheet with styles for the tabbed menu, player strip grid, and player directory list

## Testing
- not run (frontend structural change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4f106fa64833194bb29e2c5c41013