### PR TITLE
Start streaming RCON console logs when clients join

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1489,6 +1489,8 @@ io.on('connection', (socket) => {
     try {
       ensureRconBinding(row);
       await connectRcon(row);
+      sendRconCommand(row, 'console.tail 1000').catch(() => {});
+      sendRconCommand(row, 'chat.tail 100').catch(() => {});
       sendRconCommand(row, 'status').catch(() => {});
     } catch (e) {
       socket.emit('error', e.message || String(e));


### PR DESCRIPTION
## Summary
- start console and chat tailing whenever a socket joins a server
- ensure WebRCON pushes live console/chat output to clients so existing listeners receive updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f53b239c8331a669f3dff71d2c9f