### PR TITLE
Restructure server workspace into tabbed views

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -64,6 +64,65 @@ main.grid{
 .col.center{min-width:520px}
 .col.right{min-width:320px}
 
+.server-panel{
+  padding:22px 24px 36px;
+  display:flex; flex-direction:column; gap:24px;
+}
+
+.server-menu{
+  display:flex; gap:12px; flex-wrap:wrap;
+}
+
+.menu-tab{
+  appearance:none; border:1px solid var(--border); border-radius:999px;
+  padding:10px 18px; font-weight:600; font-size:14px;
+  background:linear-gradient(180deg, #1b2030 0%, #131722 100%);
+  color:var(--muted); cursor:pointer; transition:filter .15s ease, transform .05s ease;
+}
+
+.menu-tab:hover{filter:brightness(1.1)}
+.menu-tab:active{transform:translateY(1px)}
+.menu-tab.active{
+  background:rgba(225,29,72,.18); color:#fda4af;
+  border-color:rgba(225,29,72,.45); box-shadow:inset 0 0 0 1px rgba(225,29,72,.45);
+}
+
+.view-panel{display:none; flex-direction:column; gap:22px}
+.view-panel.active{display:flex}
+.card.full-width{width:100%}
+.players-strip{padding:0 18px 18px}
+.players-strip .module-message{padding:28px; text-align:center; color:var(--muted)}
+.players-strip .live-players-list{
+  display:grid; gap:16px; padding:18px 0 0;
+  grid-template-columns:repeat(auto-fill, minmax(280px, 1fr));
+}
+.players-strip .live-player-row{
+  border:1px solid var(--border); border-radius:16px;
+  padding:18px; display:flex; flex-direction:column; gap:16px;
+  background:rgba(12,15,24,.75); border-bottom:none;
+}
+.players-strip .live-player-row:hover{background:rgba(225,29,72,.12)}
+.players-strip .live-player-details{align-items:flex-start}
+
+.players-directory{padding:0}
+.players-directory .module-message{padding:24px; text-align:center}
+.player-directory{
+  list-style:none; margin:0; padding:0; display:flex; flex-direction:column;
+}
+.player-directory li{
+  display:flex; justify-content:space-between; gap:18px; align-items:flex-start;
+  padding:16px 18px; border-bottom:1px solid var(--border);
+  background:rgba(12,15,23,.6);
+}
+.player-directory li:nth-child(even){background:rgba(255,255,255,.02)}
+.player-directory strong{font-weight:600}
+.player-directory .muted{color:var(--muted)}
+.player-directory .small{font-size:12px}
+.player-directory .server-actions{display:flex; gap:10px; flex-wrap:wrap}
+
+.muted{color:var(--muted)}
+.small{font-size:12px}
+
 .card{
   background:linear-gradient(180deg, #12151f 0%, #0e1119 100%);
   border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow);

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -791,6 +791,31 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 
 .workspace-title h2 { font-size: 1.6rem; }
 
+.workspace-menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+button.menu-tab {
+  border-radius: 999px;
+  padding: 9px 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: var(--muted-strong);
+  box-shadow: none;
+  transition: transform 0.12s ease, filter 0.16s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+button.menu-tab:hover { border-color: rgba(255, 255, 255, 0.2); }
+
+button.menu-tab.active {
+  background: rgba(244, 63, 94, 0.18);
+  border-color: rgba(244, 63, 94, 0.45);
+  color: var(--accent-strong);
+  box-shadow: 0 0 0 2px rgba(244, 63, 94, 0.18);
+}
+
 .workspace-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -807,15 +832,20 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
 .summary-label { display: block; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
 .summary-card strong { font-size: 1.6rem; margin-top: 8px; display: block; }
 
-.workspace-grid {
-  display: grid;
-  grid-template-columns: 500px minmax(0, 1fr);
-  gap: 24px;
-  align-items: start;
+.workspace-views {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
-@media (max-width: 1200px) {
-  .workspace-grid { grid-template-columns: 1fr; }
+.workspace-view {
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.workspace-view.active {
+  display: flex;
 }
 
 .card {
@@ -834,6 +864,366 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.card-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card-title-group h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-controls,
+.card-actions,
+.module-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.module-actions { justify-content: flex-start; }
+
+.module-host {
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 20px;
+}
+
+.module-hidden { display: none !important; }
+
+.module-host.map-body {
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.players-live {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.module-message {
+  margin: 0;
+  padding: 26px;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--radius-sm);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.module-message.hidden { display: none; }
+
+.live-players-list {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.live-player-row {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.live-player-row:hover {
+  border-color: rgba(244, 63, 94, 0.4);
+  box-shadow: 0 16px 40px rgba(244, 63, 94, 0.12);
+}
+
+.live-player-row.active {
+  border-color: rgba(244, 63, 94, 0.6);
+  box-shadow: 0 20px 46px rgba(244, 63, 94, 0.18);
+}
+
+.live-player-identity {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.live-player-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  background: rgba(244, 63, 94, 0.2);
+  color: var(--accent-strong);
+  font-weight: 600;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+}
+
+.live-player-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.live-player-avatar.placeholder {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent-strong);
+}
+
+.live-player-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.live-player-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.live-player-name a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.live-player-name a:hover { color: var(--accent-strong); }
+
+.live-player-sub {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.live-player-hours { color: var(--muted-strong); }
+
+.live-player-details {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.live-player-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.live-player-stats .stat {
+  font-size: 0.82rem;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--muted-strong);
+}
+
+.live-player-stats .stat.health { color: #fecdd3; border-color: rgba(244, 63, 94, 0.42); }
+.live-player-stats .stat.ping { color: #bae6fd; border-color: rgba(59, 130, 246, 0.42); }
+.live-player-stats .stat.violation { color: #fef3c7; border-color: rgba(250, 204, 21, 0.38); }
+
+.live-player-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.players-directory {
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.player-directory {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.player-directory li {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.player-directory li:nth-child(even) { background: rgba(255, 255, 255, 0.05); }
+
+.player-directory strong { font-weight: 600; }
+
+.player-directory .server-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.map-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 1200px) {
+  .map-layout { grid-template-columns: 1fr; }
+}
+
+.map-view {
+  position: relative;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(9, 1, 4, 0.9);
+  min-height: 420px;
+}
+
+.map-view img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.map-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.map-overlay .map-marker {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.45);
+  transform: translate(-50%, -50%);
+}
+
+.map-overlay .map-marker.active { box-shadow: 0 0 0 3px rgba(244, 63, 94, 0.4); }
+.map-overlay .map-marker.dimmed { opacity: 0.4; }
+
+.map-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.map-summary {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.9rem;
+}
+
+.map-sidebar .row { justify-content: flex-end; }
+
+.map-player-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.map-player-list button {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--muted-strong);
+}
+
+.map-player-list button.active {
+  background: rgba(244, 63, 94, 0.18);
+  border-color: rgba(244, 63, 94, 0.45);
+  color: var(--accent-strong);
+}
+
+.map-team-info {
+  padding: 14px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.map-upload {
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.map-upload.hidden { display: none !important; }
+
+.map-upload-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.map-upload input[type="file"] {
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  color: var(--muted-strong);
+}
+
+.notice { font-size: 0.85rem; }
+.notice.hidden { display: none !important; }
+.notice.error { color: #fecdd3; }
+.notice.success { color: #bbf7d0; }
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.info-item .label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.info-item .value {
+  font-size: 1rem;
+  color: var(--muted-strong);
+  word-break: break-word;
 }
 
 pre {
@@ -920,15 +1310,39 @@ pre {
 .badge {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.badge.country {
+  background: rgba(244, 63, 94, 0.18);
+  border-color: rgba(244, 63, 94, 0.38);
+  color: var(--accent-strong);
+}
+
+.badge.vac {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #fee2e2;
+}
+
+.badge.gameban {
+  background: rgba(251, 191, 36, 0.2);
+  border-color: rgba(251, 191, 36, 0.42);
+  color: #fef3c7;
+}
+
+.badge.warn {
+  background: rgba(251, 191, 36, 0.14);
+  border-color: rgba(251, 191, 36, 0.38);
+  color: #fef08a;
 }
 
 @media (max-width: 720px) {
@@ -936,6 +1350,6 @@ pre {
   .app-header { position: static; padding: 20px; }
   .dashboard { gap: 20px; }
   .servers-section, .team-card, .workspace, .settings-panel { padding: 24px; }
-  .workspace-grid { gap: 18px; }
+  .workspace-views { gap: 20px; }
   .login-hero, .login-card { padding: 24px; }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -145,31 +145,112 @@
           </div>
           <span id="workspaceStatus" class="status-pill">offline</span>
         </div>
-        <div class="workspace-summary">
-          <div class="summary-card">
-            <span class="summary-label">Players</span>
-            <strong id="workspacePlayers">--</strong>
-          </div>
-          <div class="summary-card">
-            <span class="summary-label">Queue</span>
-            <strong id="workspaceQueue">--</strong>
-          </div>
-        </div>
-        <div class="workspace-grid">
-          <div class="card console-card">
-            <div class="card-header">
-              <h3>Console</h3>
-              <button id="btnClearConsole" class="icon" title="Clear console">✕</button>
+
+        <nav id="workspaceMenu" class="workspace-menu" aria-label="Server sections">
+          <button type="button" class="menu-tab active" data-view="players" aria-pressed="true">Players</button>
+          <button type="button" class="menu-tab" data-view="map" aria-pressed="false">Map</button>
+          <button type="button" class="menu-tab" data-view="console" aria-pressed="false">Console</button>
+          <button type="button" class="menu-tab" data-view="dashboard" aria-pressed="false">Dashboard</button>
+        </nav>
+
+        <div class="workspace-views">
+          <section id="workspaceViewPlayers" class="workspace-view active" data-view="players" aria-hidden="false">
+            <div class="card players-card" data-module-card="live-players">
+              <div class="card-header">
+                <div class="card-title-group">
+                  <h3><span data-module-title>Current Players</span> <span id="player-count" class="muted small">(0)</span></h3>
+                  <div class="module-actions" data-module-actions></div>
+                </div>
+                <div class="card-controls">
+                  <button id="show-all" class="ghost small">Show everyone</button>
+                </div>
+              </div>
+              <div class="module-host players-live" data-module-slot="live-players"></div>
             </div>
-            <pre id="console"></pre>
-            <div class="row">
-              <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
-              <button id="btnSend" class="accent">Send</button>
+
+            <div class="card directory-card" data-module-card="players-directory">
+              <div class="card-header">
+                <div class="card-title-group">
+                  <h3><span data-module-title>All Players</span></h3>
+                  <div class="module-actions" data-module-actions></div>
+                </div>
+              </div>
+              <div class="module-host players-directory" data-module-slot="players-directory"></div>
             </div>
-            <div class="row quick-row" id="quickCommands"></div>
-          </div>
-          <div id="moduleColumn" class="module-stack"></div>
+          </section>
+
+          <section id="workspaceViewMap" class="workspace-view" data-view="map" aria-hidden="true">
+            <div class="card map-card" data-module-card="live-map">
+              <div class="card-header">
+                <div class="card-title-group">
+                  <h3><span data-module-title>Live Map</span></h3>
+                  <div class="module-actions" data-module-actions></div>
+                </div>
+              </div>
+              <div class="module-host map-body" data-module-slot="live-map"></div>
+            </div>
+          </section>
+
+          <section id="workspaceViewConsole" class="workspace-view" data-view="console" aria-hidden="true">
+            <div class="card console-card">
+              <div class="card-header">
+                <h3>Console</h3>
+                <div class="card-controls">
+                  <button id="btnClearConsole" class="icon" title="Clear console">✕</button>
+                </div>
+              </div>
+              <pre id="console"></pre>
+              <div class="row">
+                <input id="cmd" placeholder="say &quot;Hello&quot; | status | kick &lt;steamid&gt; reason">
+                <button id="btnSend" class="accent">Send</button>
+              </div>
+              <div class="row quick-row" id="quickCommands"></div>
+            </div>
+          </section>
+
+          <section id="workspaceViewDashboard" class="workspace-view" data-view="dashboard" aria-hidden="true">
+            <div class="workspace-summary">
+              <div class="summary-card">
+                <span class="summary-label">Players</span>
+                <strong id="workspacePlayers">--</strong>
+              </div>
+              <div class="summary-card">
+                <span class="summary-label">Queue</span>
+                <strong id="workspaceQueue">--</strong>
+              </div>
+              <div class="summary-card">
+                <span class="summary-label">Sleepers</span>
+                <strong id="workspaceSleepers">--</strong>
+              </div>
+            </div>
+
+            <div class="card info-card">
+              <div class="card-header">
+                <h3>Server Overview</h3>
+              </div>
+              <div class="info-grid">
+                <div class="info-item">
+                  <span class="label">Hostname</span>
+                  <span class="value" id="workspaceInfoHostname">—</span>
+                </div>
+                <div class="info-item">
+                  <span class="label">Address</span>
+                  <span class="value" id="workspaceInfoAddress">—</span>
+                </div>
+                <div class="info-item">
+                  <span class="label">Last Check</span>
+                  <span class="value" id="workspaceInfoLastCheck">—</span>
+                </div>
+                <div class="info-item">
+                  <span class="label">Status Notes</span>
+                  <span class="value" id="workspaceInfoNotes">—</span>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
+
+        <div id="moduleFallback" class="module-stack hidden" aria-hidden="true"></div>
       </section>
 
       <section id="settingsPanel" class="hidden settings-panel">
@@ -246,6 +327,7 @@
   </div>
 
   <script src="assets/modules/module-loader.js"></script>
+  <script src="assets/modules/live-players.js"></script>
   <script src="assets/modules/players.js"></script>
   <script src="assets/modules/map.js"></script>
   <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" crossorigin="anonymous"></script>

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -9,6 +9,7 @@
     <script defer src="/assets/modules/live-console.js"></script>
     <script defer src="/assets/modules/map.js"></script>
     <script defer src="/assets/modules/live-players.js"></script>
+    <script defer src="/assets/modules/players.js"></script>
     <script defer src="/assets/js/panel-shell.js"></script>
   </head>
 <body class="app">
@@ -24,66 +25,102 @@
     </div>
   </header>
 
-  <main class="grid">
-    <!-- Left: Live Console -->
-    <section class="col left card">
-      <div class="card-head">
-        <div class="card-title">Console</div>
+  <main class="server-panel">
+    <nav class="server-menu" aria-label="Server sections">
+      <button class="menu-tab active" type="button" data-target="players">Players</button>
+      <button class="menu-tab" type="button" data-target="map">Map</button>
+      <button class="menu-tab" type="button" data-target="console">Console</button>
+      <button class="menu-tab" type="button" data-target="dashboard">Dashboard</button>
+    </nav>
+
+    <section class="view-panel active" data-view="players">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Current Players <span id="player-count" class="muted">(0)</span></div>
+          <div class="card-tools">
+            <button class="btn ghost small" id="show-all">Show everyone</button>
+          </div>
+        </div>
+        <div class="card-body no-pad players-strip">
+          <div class="live-players-board" data-module="live-players"
+               data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
       </div>
-      <div class="card-body no-pad">
-        <div class="console" data-module="live-console" data-props='{}'></div>
-      </div>
-      <div class="console-input">
-        <input type="text" id="console-cmd" placeholder="Enter console command..." />
-        <button class="btn danger" id="console-send">Send</button>
+
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">All Players</div>
+        </div>
+        <div class="card-body players-directory" data-module="players-directory"
+             data-props='{"serverId":"__SERVER_ID__"}'></div>
       </div>
     </section>
 
-    <!-- Center: Player map -->
-    <section class="col center">
-      <div class="card map-card player-map-card">
+    <section class="view-panel" data-view="map">
+      <div class="card full-width map-card">
         <div class="card-head">
-          <div class="card-title">Player Map</div>
-          <nav class="subnav" aria-label="Player views">
-            <button type="button" class="subnav-btn active" id="player-view-all">All Players</button>
-          </nav>
+          <div class="card-title">Live Map</div>
         </div>
         <div class="card-body no-pad">
-          <!-- Your live-map module mounts here -->
           <div class="map-wrap" data-module="live-map" id="live-map-slot"
                data-props='{"serverId":"__SERVER_ID__"}'></div>
         </div>
-        <div class="card-foot player-list-foot">
-          <div class="player-list-head">
-            <div class="player-list-title">All Players <span id="player-count" class="muted">(0)</span></div>
-            <div class="card-tools">
-              <button class="btn ghost small" id="show-all">Show everyone</button>
-            </div>
-          </div>
-          <div class="player-list-body">
-            <div class="live-players-board" data-module="live-players"
-                 data-props='{"serverId":"__SERVER_ID__"}'></div>
-          </div>
-        </div>
       </div>
-
     </section>
 
-    <!-- Right: Server/Player Info -->
-    <aside class="col right card">
-      <div class="card-head">
-        <div class="card-title" id="info-title">Server Info</div>
+    <section class="view-panel" data-view="console">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Console</div>
+        </div>
+        <div class="card-body no-pad">
+          <div class="console" data-module="live-console" data-props='{}'></div>
+        </div>
+        <div class="console-input">
+          <input type="text" id="console-cmd" placeholder="Enter console command..." />
+          <button class="btn danger" id="console-send">Send</button>
+        </div>
       </div>
-      <div class="card-body" id="info-content">
-        <!-- Default server info module slot -->
-        <div data-module="server-info" data-props='{"serverId":"__SERVER_ID__"}'></div>
-      </div>
-      <div class="card-foot" id="info-actions">
-        <button class="btn ghost" id="btn-restart">Restart Server</button>
-        <button class="btn ghost" id="btn-saveworld">Save World</button>
-      </div>
-    </aside>
+    </section>
 
+    <section class="view-panel" data-view="dashboard">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title" id="info-title">Server Info</div>
+        </div>
+        <div class="card-body" id="info-content">
+          <div data-module="server-info" data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+        <div class="card-foot" id="info-actions">
+          <button class="btn ghost" id="btn-restart">Restart Server</button>
+          <button class="btn ghost" id="btn-saveworld">Save World</button>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const tabs = Array.from(document.querySelectorAll('.menu-tab'));
+      const views = Array.from(document.querySelectorAll('.view-panel'));
+
+      function activate(target) {
+        tabs.forEach((btn) => {
+          const isActive = btn.dataset.target === target;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+        views.forEach((panel) => {
+          panel.classList.toggle('active', panel.dataset.view === target);
+        });
+      }
+
+      tabs.forEach((btn) => {
+        btn.addEventListener('click', () => activate(btn.dataset.target));
+      });
+
+      activate('players');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the workspace grid on the server detail screen with tabbed players, map, console, and dashboard views
- wire the module loader to dedicated containers for live players, player directory, and map content while adding a dashboard info card
- expand the frontend stylesheet with navigation tab styles and module-specific theming for players, map, and dashboard layouts

## Testing
- not run (frontend structural changes)

------
https://chatgpt.com/codex/tasks/task_e_68d4f106fa64833194bb29e2c5c41013