### PR TITLE
Improve live map player list presentation

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -196,15 +196,25 @@ main.grid{
 .map-summary strong{font-weight:700}
 .map-sidebar .row{display:flex; justify-content:flex-end}
 .map-sidebar .row button{border-radius:999px}
-.map-player-list{display:flex; flex-wrap:wrap; gap:10px}
-.map-player-list button{
-  flex:1 1 220px; text-align:left; padding:12px 14px; border-radius:12px;
-  background:rgba(17,20,30,.88); border:1px solid rgba(148,163,184,.12); color:var(--text);
-  display:flex; align-items:center; justify-content:space-between; gap:12px;
+.map-player-list{overflow-x:auto}
+.map-player-table{width:100%; min-width:420px; border-collapse:collapse; font-size:.9rem}
+.map-player-table thead th{
+  text-align:left; font-size:.7rem; text-transform:uppercase; letter-spacing:.06em;
+  color:var(--muted); padding:6px 10px; border-bottom:1px solid rgba(148,163,184,.25);
 }
-.map-player-list button:hover{background:rgba(225,29,72,.12); border-color:rgba(225,29,72,.35)}
-.map-player-list button.active{background:rgba(225,29,72,.18); border-color:rgba(225,29,72,.55)}
-.map-player-tag{display:flex; gap:8px; color:var(--muted); font-size:12px}
+.map-player-table tbody td{padding:10px; border-bottom:1px solid rgba(15,23,42,.65)}
+.map-player-table tbody tr{cursor:pointer; transition:background .15s ease, color .15s ease}
+.map-player-table tbody tr:hover{background:rgba(148,163,184,.08)}
+.map-player-table tbody tr:last-child td{border-bottom:none}
+.map-player-table tbody tr.active{background:rgba(225,29,72,.18); color:var(--accent-strong)}
+.map-player-table tbody tr.dimmed{opacity:.45}
+.map-player-name-cell{display:flex; flex-direction:column; gap:4px}
+.map-player-name{display:inline-flex; align-items:center; gap:8px; font-weight:600}
+.map-player-color{width:12px; height:12px; border-radius:999px; box-shadow:0 0 0 2px rgba(15,23,42,.65)}
+.map-player-sub{font-size:.75rem; color:var(--muted)}
+.map-player-team{white-space:nowrap; font-size:.85rem; color:var(--muted-strong)}
+.map-player-stat{text-align:right; font-variant-numeric:tabular-nums}
+.map-filter-note{margin-top:8px}
 .map-team-info{display:flex; flex-direction:column; gap:10px; background:rgba(15,19,28,.78); border-radius:12px; padding:14px; border:1px solid rgba(148,163,184,.1)}
 .map-team-info .team-row{display:flex; align-items:center; justify-content:space-between; gap:12px}
 .map-team-info .team-color{width:14px; height:14px; border-radius:50%; border:2px solid rgba(15,23,42,.6)}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1138,23 +1138,92 @@ button.menu-tab.active {
 .map-sidebar .row { justify-content: flex-end; }
 
 .map-player-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  overflow-x: auto;
 }
 
-.map-player-list button {
-  padding: 6px 12px;
+.map-player-table {
+  width: 100%;
+  min-width: 420px;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.map-player-table thead th {
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.map-player-table tbody td {
+  padding: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.map-player-table tbody tr {
+  transition: background 0.15s ease, color 0.15s ease;
+  cursor: pointer;
+}
+
+.map-player-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.map-player-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.map-player-table tbody tr.active {
+  background: rgba(244, 63, 94, 0.18);
+  color: var(--accent-strong);
+}
+
+.map-player-table tbody tr.dimmed {
+  opacity: 0.45;
+}
+
+.map-player-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.map-player-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.map-player-color {
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
+}
+
+.map-player-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.map-player-team {
+  white-space: nowrap;
+  font-size: 0.85rem;
   color: var(--muted-strong);
 }
 
-.map-player-list button.active {
-  background: rgba(244, 63, 94, 0.18);
-  border-color: rgba(244, 63, 94, 0.45);
-  color: var(--accent-strong);
+.map-player-stat {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.map-filter-note {
+  margin-top: 8px;
 }
 
 .map-team-info {


### PR DESCRIPTION
## Summary
- render the live map player list as a sortable-style table with player, team, ping, health, and connected columns
- highlight selected players or teams while dimming the rest and add guidance copy when filters are active
- refresh styling for both light and dark themes to support the new table layout

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d4f953d1e88331b30b866bd4b1b815