### PR TITLE
Improve serverinfo parsing for map metadata

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -227,6 +227,15 @@ function parseStatusMessage(message) {
   return info;
 }
 
+function extractInteger(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  const match = String(value).match(/-?\d+/);
+  if (!match) return null;
+  const num = parseInt(match[0], 10);
+  return Number.isFinite(num) ? num : null;
+}
+
 function parseServerInfoMessage(message) {
   const info = {
     raw: message,
@@ -235,25 +244,58 @@ function parseServerInfoMessage(message) {
     seed: null
   };
   if (!message) return info;
-  const lines = message.split(/\r?\n/);
-  for (const line of lines) {
-    const parts = line.split(':');
-    if (parts.length < 2) continue;
-    const key = parts.shift().trim().toLowerCase();
-    const value = parts.join(':').trim();
-    if (!value) continue;
-    if (key.includes('map')) {
-      if (!key.includes('seed') && !key.includes('size')) info.mapName = value;
+
+  const assign = (key, value) => {
+    const lower = String(key || '').trim().toLowerCase();
+    if (!lower) return;
+    const trimmedValue = typeof value === 'string' ? value.trim() : value;
+    if (trimmedValue == null || trimmedValue === '') return;
+
+    if (lower.includes('map') && !lower.includes('seed') && !lower.includes('size') && !lower.includes('url')) {
+      if (!info.mapName) info.mapName = String(trimmedValue);
     }
-    if (key.includes('world size') || key === 'worldsize' || key === 'size') {
-      const size = parseInt(value, 10);
-      if (Number.isFinite(size)) info.size = size;
+
+    if (lower.includes('size')) {
+      const size = extractInteger(trimmedValue);
+      if (size != null) info.size = size;
     }
-    if (key.includes('seed')) {
-      const seed = parseInt(value, 10);
-      if (Number.isFinite(seed)) info.seed = seed;
+
+    if (lower.includes('seed')) {
+      const seed = extractInteger(trimmedValue);
+      if (seed != null) info.seed = seed;
+    }
+  };
+
+  const trimmed = typeof message === 'string' ? message.trim() : '';
+  let parsedJson = false;
+  if (trimmed.startsWith('{')) {
+    try {
+      const data = JSON.parse(trimmed);
+      if (data && typeof data === 'object') {
+        for (const [key, value] of Object.entries(data)) assign(key, value);
+        parsedJson = true;
+      }
+    } catch {
+      /* ignore JSON parse errors */
     }
   }
+
+  if (!parsedJson) {
+    const lines = trimmed.split(/\r?\n/);
+    for (const line of lines) {
+      const parts = line.split(':');
+      if (parts.length < 2) continue;
+      const key = parts.shift();
+      const value = parts.join(':');
+      assign(key, value);
+    }
+  }
+
+  if (info.mapName && info.size == null) {
+    const size = extractInteger(info.mapName);
+    if (size != null) info.size = size;
+  }
+
   return info;
 }
 
@@ -804,6 +846,23 @@ rconEventBus.on('monitor_status', (serverId, payload) => {
   const statusReply = findReply('status') || payload?.reply || null;
   const statusMessage = statusReply?.Message || statusReply?.message || '';
   const details = parseStatusMessage(statusMessage);
+
+  const serverInfoReply = findReply('serverinfo');
+  const serverInfoMessage = serverInfoReply?.Message || serverInfoReply?.message || '';
+  if (serverInfoMessage) {
+    try {
+      const info = parseServerInfoMessage(serverInfoMessage);
+      if (info) {
+        cacheServerInfo(id, info);
+        details.serverInfo = info;
+        details.serverinfo = info;
+        details.serverInfoRaw = serverInfoMessage;
+      }
+    } catch (err) {
+      console.warn('Failed to parse serverinfo response', err);
+    }
+  }
+
   recordStatus(id, {
     ok: true,
     lastCheck: new Date().toISOString(),
@@ -880,7 +939,7 @@ async function refreshMonitoredServers() {
         monitorController = startAutoMonitor(list, {
           intervalMs: MONITOR_INTERVAL,
           timeoutMs: MONITOR_TIMEOUT,
-          commands: ['status', 'playerlist']
+          commands: ['status', 'playerlist', 'serverinfo']
         });
       } else {
         monitorController.update(list);


### PR DESCRIPTION
## Summary
- enhance serverinfo parsing so map name, size, and seed are captured across JSON and Map Size/Seed variants
- add integer extraction helper to pick up numeric details from mixed-format serverinfo responses, including map name fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5059b40f48331821953e8272a0784