### PR TITLE
Show player detail modal with manual Steam refresh

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -26,6 +26,9 @@ body.app{
   color:var(--text); font-family:var(--font);
 }
 
+.hidden{display:none!important}
+body.modal-open{overflow:hidden}
+
 .topbar{
   display:flex; align-items:center; justify-content:space-between;
   padding:14px 22px; border-bottom:1px solid var(--border);
@@ -113,8 +116,11 @@ main.grid{
   display:flex; justify-content:space-between; gap:18px; align-items:flex-start;
   padding:16px 18px; border-bottom:1px solid var(--border);
   background:rgba(12,15,23,.6);
+  cursor:pointer; transition:background .15s ease, border-color .15s ease;
 }
 .player-directory li:nth-child(even){background:rgba(255,255,255,.02)}
+.player-directory li:hover{background:rgba(225,29,72,.12); border-color:rgba(225,29,72,.35)}
+.player-directory li:focus-visible{outline:2px solid rgba(225,29,72,.6); outline-offset:2px}
 .player-directory strong{font-weight:600}
 .player-directory .muted{color:var(--muted)}
 .player-directory .small{font-size:12px}
@@ -271,6 +277,63 @@ main.grid{
 .dot{width:8px; height:8px; border-radius:50%}
 .health{padding:3px 8px; border-radius:8px; background:#0f172a; color:#a3ffbf; border:1px solid rgba(34,197,94,.25)}
 .ping{padding:3px 8px; border-radius:8px; background:#13151f; color:#93c5fd; border:1px solid rgba(59,130,246,.25)}
+
+.player-modal-backdrop{
+  position:fixed; inset:0; z-index:90;
+  background:rgba(6,9,15,.72);
+  backdrop-filter:blur(12px);
+  display:flex; align-items:flex-start; justify-content:center;
+  padding:60px 16px 30px; overflow:auto;
+}
+.player-modal-backdrop.hidden{display:none}
+.player-modal{
+  width:min(560px, 100%);
+  background:linear-gradient(180deg, #121722 0%, #0b0f19 100%);
+  border:1px solid var(--border);
+  border-radius:var(--radius-lg);
+  box-shadow:0 20px 48px rgba(0,0,0,.55);
+  display:flex; flex-direction:column; overflow:hidden;
+  animation:playerModalIn .18s ease;
+}
+.player-modal-header{
+  padding:20px 22px; display:flex; align-items:center; justify-content:space-between;
+  gap:16px; border-bottom:1px solid var(--border);
+}
+.player-modal-title{display:flex; align-items:center; gap:16px}
+.player-modal-avatar{
+  width:64px; height:64px; border-radius:18px; overflow:hidden;
+  background:var(--surface-2); display:grid; place-items:center;
+  font-weight:700; color:var(--muted); text-transform:uppercase;
+}
+.player-modal-avatar img{width:100%; height:100%; object-fit:cover}
+.player-modal-heading{display:flex; flex-direction:column; gap:6px}
+.player-modal-name{font-weight:700; font-size:1.1rem}
+.player-modal-persona{font-size:.85rem}
+.player-modal-meta{font-size:.8rem; color:var(--muted)}
+.player-modal-badges{display:flex; gap:8px; flex-wrap:wrap; margin-top:4px}
+.player-modal-body{padding:22px 22px 24px; display:flex; flex-direction:column; gap:20px}
+.player-modal-loading{padding:10px 12px; border-radius:10px; background:rgba(148,163,184,.08); color:var(--muted);}
+.player-modal-details{display:grid; grid-template-columns: 160px 1fr; gap:10px 18px; margin:0}
+.player-modal-details dt{font-size:.8rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted)}
+.player-modal-details dd{margin:0; font-weight:600; color:var(--text)}
+.player-modal-events h4{margin:0 0 10px; font-size:.95rem; font-weight:600}
+.player-event-list{list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px}
+.player-event-row{background:rgba(15,19,30,.7); border:1px solid rgba(148,163,184,.18); border-radius:12px; padding:10px 12px; display:flex; flex-direction:column; gap:4px}
+.player-event-empty{background:rgba(15,19,30,.5); border:1px dashed rgba(148,163,184,.18); border-radius:12px; padding:12px}
+.player-event-row strong{font-weight:600}
+.event-meta{font-size:.75rem; color:var(--muted)}
+.player-modal-footer{padding:18px 22px; border-top:1px solid var(--border); display:flex; flex-wrap:wrap; gap:14px; align-items:center; justify-content:space-between}
+.player-modal-status{font-size:.8rem; color:var(--muted)}
+.player-modal-status.hidden{display:none!important}
+.player-modal-status[data-variant="success"]{color:#bbf7d0}
+.player-modal-status[data-variant="error"]{color:#fecaca}
+.player-modal-status[data-variant="warn"]{color:#fde68a}
+.player-modal-actions{display:flex; gap:10px; flex-wrap:wrap}
+
+@keyframes playerModalIn{
+  from{transform:translateY(18px); opacity:0}
+  to{transform:translateY(0); opacity:1}
+}
 
 .right .kv{display:grid; grid-template-columns: 100px 1fr; gap:8px; margin:10px 0}
 .right .kv .k{color:var(--muted)}

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -30,8 +30,20 @@
         message?.removeAttribute('data-variant');
       }
 
+      const modalState = {
+        open: false,
+        steamid: null,
+        base: null,
+        details: null,
+        refreshing: false
+      };
+
+      const modal = createPlayerModal();
+
       function render(players) {
         list.innerHTML = '';
+        state.players = Array.isArray(players) ? players : [];
+        window.dispatchEvent?.(new CustomEvent('players:list', { detail: { players: state.players } }));
         if (!Array.isArray(players) || players.length === 0) {
           setMessage('No tracked players for this server yet. Import Steam profiles or let players connect to populate this list.');
           return;
@@ -39,6 +51,9 @@
         clearMessage();
         for (const p of players) {
           const li = document.createElement('li');
+          li.dataset.steamid = p.steamid || '';
+          li.tabIndex = 0;
+          li.setAttribute('role', 'button');
           const left = document.createElement('div');
           const strong = document.createElement('strong');
           strong.textContent = p.display_name || p.persona || p.steamid;
@@ -71,13 +86,26 @@
           }
           li.appendChild(left);
           li.appendChild(right);
+          const openDetails = () => openModal(p);
+          li.addEventListener('click', openDetails);
+          li.addEventListener('keydown', (ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+              ev.preventDefault();
+              openDetails();
+            }
+          });
           list.appendChild(li);
+        }
+        if (modalState.open && modalState.steamid) {
+          const updated = state.players.find((player) => String(player.steamid || '') === modalState.steamid);
+          if (updated) renderModal(updated, null);
         }
       }
 
       const state = {
         serverId: null,
-        isLoading: false
+        isLoading: false,
+        players: []
       };
 
       async function refresh(reason, serverIdOverride){
@@ -120,6 +148,417 @@
         return date.toLocaleString();
       }
 
+      function formatPlaytime(minutes, visibility) {
+        const value = Number(minutes);
+        if (!Number.isFinite(value)) {
+          if (Number(visibility) === 3) return 'No recorded hours';
+          return 'Profile private';
+        }
+        if (value <= 0) return 'No recorded hours';
+        const hours = value / 60;
+        if (hours >= 100) return `${Math.round(hours)} h`;
+        return `${hours.toFixed(1)} h`;
+      }
+
+      function formatVisibility(visibility) {
+        const value = Number(visibility);
+        switch (value) {
+          case 1: return 'Private';
+          case 2: return 'Friends only';
+          case 3: return 'Public';
+          case 4: return 'Users only';
+          case 5: return 'Public';
+          default: return '—';
+        }
+      }
+
+      function formatLastBan(days) {
+        const value = Number(days);
+        if (!Number.isFinite(value) || value < 0) return '—';
+        if (value === 0) return 'Today';
+        if (value === 1) return '1 day ago';
+        return `${value} days ago`;
+      }
+
+      function avatarInitial(name = '') {
+        const trimmed = String(name || '').trim();
+        if (!trimmed) return '?';
+        return String.fromCodePoint(trimmed.codePointAt(0) || 63).toUpperCase();
+      }
+
+      function openModal(player) {
+        if (!player || !modal) return;
+        const steamid = String(player.steamid || '').trim();
+        modalState.open = true;
+        modalState.steamid = steamid || null;
+        renderModal(player, null);
+        setModalStatus('');
+        setModalLoading(false);
+        modal.show();
+        if (steamid) {
+          loadPlayerDetails(steamid, { basePlayer: player, showLoading: true });
+        } else {
+          setModalStatus('Steam ID is missing for this entry.', 'warn');
+        }
+      }
+
+      function closeModal() {
+        if (!modalState.open || !modal) return;
+        modalState.open = false;
+        modalState.steamid = null;
+        modalState.base = null;
+        modalState.details = null;
+        modalState.refreshing = false;
+        setModalStatus('');
+        setModalLoading(false);
+        modal.hide();
+      }
+
+      function renderModal(baseOverride = null, detailsOverride = null) {
+        if (!modal) return;
+        if (baseOverride) modalState.base = { ...baseOverride };
+        if (detailsOverride) modalState.details = { ...detailsOverride };
+        const base = modalState.base || {};
+        const detail = modalState.details || {};
+        const combined = { ...base, ...detail };
+        const displayName = combined.display_name || combined.persona || combined.steamid || 'Unknown player';
+        const persona = combined.persona || '—';
+        const steamid = combined.steamid || '—';
+        const country = combined.country || '';
+        const nameBadge = modal.elements.name;
+        if (nameBadge) nameBadge.textContent = displayName;
+        if (modal.elements.meta) modal.elements.meta.textContent = steamid;
+        if (modal.elements.avatar) {
+          modal.elements.avatar.innerHTML = '';
+          modal.elements.avatar.classList.remove('placeholder');
+          if (combined.avatar) {
+            const img = document.createElement('img');
+            img.src = combined.avatar;
+            img.alt = `${displayName} avatar`;
+            img.loading = 'lazy';
+            modal.elements.avatar.appendChild(img);
+          } else {
+            modal.elements.avatar.classList.add('placeholder');
+            modal.elements.avatar.textContent = avatarInitial(displayName);
+          }
+        }
+        if (modal.elements.badges) {
+          modal.elements.badges.innerHTML = '';
+          if (country) {
+            const badge = document.createElement('span');
+            badge.className = 'badge country';
+            badge.textContent = country;
+            modal.elements.badges.appendChild(badge);
+          }
+          const vac = Number(combined.vac_banned) > 0;
+          if (vac) {
+            const badge = document.createElement('span');
+            badge.className = 'badge vac';
+            badge.textContent = 'VAC';
+            modal.elements.badges.appendChild(badge);
+          }
+          const gameBans = Number(combined.game_bans || combined.gameBans || 0);
+          if (gameBans > 0) {
+            const badge = document.createElement('span');
+            badge.className = 'badge gameban';
+            badge.textContent = `${gameBans} game ban${gameBans === 1 ? '' : 's'}`;
+            modal.elements.badges.appendChild(badge);
+          }
+        }
+        if (modal.elements.persona) modal.elements.persona.textContent = persona && persona !== displayName ? persona : '';
+        if (modal.elements.details) {
+          const entries = [
+            ['Display name', combined.display_name || '—'],
+            ['Persona', persona],
+            ['Steam ID', steamid],
+            ['Country', country || '—'],
+            ['First seen', formatTimestamp(combined.first_seen) || '—'],
+            ['Last seen', formatTimestamp(combined.last_seen) || '—'],
+            ['Last address', combined.last_ip ? `${combined.last_ip}${combined.last_port ? ':' + combined.last_port : ''}` : '—'],
+            ['Rust playtime', formatPlaytime(combined.rust_playtime_minutes, combined.visibility)],
+            ['Profile visibility', formatVisibility(combined.visibility)],
+            ['VAC ban', Number(combined.vac_banned) > 0 ? 'Yes' : 'No'],
+            ['Game bans', `${Number(combined.game_bans || 0) || 0}`],
+            ['Last ban', formatLastBan(combined.last_ban_days)],
+            ['Profile updated', formatTimestamp(combined.updated_at) || '—'],
+            ['Playtime updated', formatTimestamp(combined.playtime_updated_at) || '—']
+          ];
+          modal.elements.details.innerHTML = '';
+          for (const [label, value] of entries) {
+            const dt = document.createElement('dt');
+            dt.textContent = label;
+            const dd = document.createElement('dd');
+            dd.textContent = value || '—';
+            modal.elements.details.appendChild(dt);
+            modal.elements.details.appendChild(dd);
+          }
+        }
+        if (modal.elements.events) {
+          const events = Array.isArray(detail.events) ? detail.events : [];
+          modal.elements.events.innerHTML = '';
+          const listEl = modal.elements.events;
+          if (events.length === 0) {
+            const li = document.createElement('li');
+            li.className = 'player-event-empty muted small';
+            li.textContent = 'No events recorded for this player yet.';
+            listEl.appendChild(li);
+          } else {
+            const recent = events.slice(0, 8);
+            for (const event of recent) {
+              const li = document.createElement('li');
+              li.className = 'player-event-row';
+              const title = document.createElement('strong');
+              title.textContent = event.event || 'Event';
+              li.appendChild(title);
+              const meta = document.createElement('div');
+              meta.className = 'event-meta';
+              const parts = [];
+              const created = formatTimestamp(event.created_at || event.createdAt);
+              if (created) parts.push(created);
+              if (event.server_id || event.serverId) parts.push(`Server ${event.server_id || event.serverId}`);
+              if (event.note) parts.push(event.note);
+              meta.textContent = parts.join(' · ');
+              li.appendChild(meta);
+              listEl.appendChild(li);
+            }
+          }
+        }
+        updateActions(combined);
+      }
+
+      function updateActions(combined) {
+        const profileUrl = combined.profileurl || combined.profile_url || '';
+        if (modal.elements.profileLink) {
+          if (profileUrl) {
+            modal.elements.profileLink.classList.remove('hidden');
+            modal.elements.profileLink.href = profileUrl;
+          } else {
+            modal.elements.profileLink.classList.add('hidden');
+            modal.elements.profileLink.removeAttribute('href');
+          }
+        }
+        if (modal.elements.refreshBtn) {
+          const hasSteam = Boolean(combined.steamid);
+          modal.elements.refreshBtn.disabled = modalState.refreshing || !hasSteam;
+          modal.elements.refreshBtn.textContent = modalState.refreshing ? 'Refreshing…' : 'Force Steam Refresh';
+        }
+      }
+
+      function setModalStatus(message, variant = 'info') {
+        if (!modal?.elements.status) return;
+        const status = modal.elements.status;
+        if (!message) {
+          status.textContent = '';
+          status.classList.add('hidden');
+          status.removeAttribute('data-variant');
+          return;
+        }
+        status.textContent = message;
+        status.classList.remove('hidden');
+        status.dataset.variant = variant;
+      }
+
+      function setModalLoading(isLoading) {
+        if (!modal?.elements.loading) return;
+        modal.elements.loading.classList.toggle('hidden', !isLoading);
+      }
+
+      async function loadPlayerDetails(steamid, { showLoading = false, basePlayer = null } = {}) {
+        if (!steamid) return;
+        const target = steamid;
+        if (basePlayer) renderModal(basePlayer, null);
+        if (showLoading) setModalLoading(true);
+        try {
+          const details = await ctx.api(`/api/players/${steamid}`);
+          if (!modalState.open || modalState.steamid !== target) return;
+          renderModal(null, details);
+          setModalStatus('');
+        } catch (err) {
+          if (ctx.errorCode?.(err) === 'unauthorized') {
+            ctx.handleUnauthorized?.();
+            closeModal();
+            return;
+          }
+          setModalStatus('Unable to load latest player details: ' + (ctx.describeError?.(err) || err?.message || 'Unknown error'), 'error');
+        } finally {
+          if (showLoading) setModalLoading(false);
+        }
+      }
+
+      async function forceSteamRefresh() {
+        if (!modalState.open || !modalState.steamid || modalState.refreshing) return;
+        modalState.refreshing = true;
+        renderModal(null, null);
+        setModalStatus('Requesting fresh Steam profile…');
+        try {
+          await ctx.api('/api/steam/sync', { steamids: [modalState.steamid] }, 'POST');
+          setModalStatus('Steam profile refresh requested. Updating record…', 'success');
+          await refresh('steam-refresh');
+          const updated = state.players.find((p) => String(p.steamid || '') === modalState.steamid);
+          if (updated) renderModal(updated, null);
+          await loadPlayerDetails(modalState.steamid, { showLoading: true });
+        } catch (err) {
+          if (ctx.errorCode?.(err) === 'unauthorized') {
+            ctx.handleUnauthorized?.();
+            closeModal();
+            return;
+          }
+          setModalStatus('Failed to refresh Steam profile: ' + (ctx.describeError?.(err) || err?.message || 'Unknown error'), 'error');
+        } finally {
+          modalState.refreshing = false;
+          renderModal(null, null);
+        }
+      }
+
+      function createPlayerModal() {
+        const overlay = document.createElement('div');
+        overlay.className = 'player-modal-backdrop hidden';
+        overlay.setAttribute('aria-hidden', 'true');
+        overlay.dataset.modal = 'player';
+        const dialog = document.createElement('article');
+        dialog.className = 'player-modal';
+        dialog.setAttribute('role', 'dialog');
+        dialog.setAttribute('aria-modal', 'true');
+        overlay.appendChild(dialog);
+
+        const header = document.createElement('header');
+        header.className = 'player-modal-header';
+        dialog.appendChild(header);
+
+        const titleGroup = document.createElement('div');
+        titleGroup.className = 'player-modal-title';
+        header.appendChild(titleGroup);
+
+        const avatar = document.createElement('div');
+        avatar.className = 'player-modal-avatar';
+        titleGroup.appendChild(avatar);
+
+        const textGroup = document.createElement('div');
+        textGroup.className = 'player-modal-heading';
+        titleGroup.appendChild(textGroup);
+
+        const name = document.createElement('div');
+        name.className = 'player-modal-name';
+        textGroup.appendChild(name);
+
+        const persona = document.createElement('div');
+        persona.className = 'player-modal-persona muted';
+        textGroup.appendChild(persona);
+
+        const meta = document.createElement('div');
+        meta.className = 'player-modal-meta';
+        textGroup.appendChild(meta);
+
+        const badges = document.createElement('div');
+        badges.className = 'player-modal-badges';
+        textGroup.appendChild(badges);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'btn ghost small player-modal-close';
+        closeBtn.textContent = '×';
+        closeBtn.setAttribute('aria-label', 'Close player details');
+        header.appendChild(closeBtn);
+
+        const body = document.createElement('div');
+        body.className = 'player-modal-body';
+        dialog.appendChild(body);
+
+        const loading = document.createElement('div');
+        loading.className = 'player-modal-loading muted small hidden';
+        loading.textContent = 'Loading latest profile…';
+        body.appendChild(loading);
+
+        const details = document.createElement('dl');
+        details.className = 'player-modal-details';
+        body.appendChild(details);
+
+        const eventsWrap = document.createElement('section');
+        eventsWrap.className = 'player-modal-events';
+        const eventsTitle = document.createElement('h4');
+        eventsTitle.textContent = 'Recent events';
+        eventsWrap.appendChild(eventsTitle);
+        const eventsList = document.createElement('ul');
+        eventsList.className = 'player-event-list';
+        eventsWrap.appendChild(eventsList);
+        body.appendChild(eventsWrap);
+
+        const footer = document.createElement('footer');
+        footer.className = 'player-modal-footer';
+        dialog.appendChild(footer);
+
+        const status = document.createElement('div');
+        status.className = 'player-modal-status hidden';
+        footer.appendChild(status);
+
+        const actions = document.createElement('div');
+        actions.className = 'player-modal-actions';
+        const refreshBtn = document.createElement('button');
+        refreshBtn.type = 'button';
+        refreshBtn.className = 'btn small';
+        refreshBtn.textContent = 'Force Steam Refresh';
+        actions.appendChild(refreshBtn);
+        const profileLink = document.createElement('a');
+        profileLink.className = 'btn ghost small hidden';
+        profileLink.textContent = 'Open Steam Profile';
+        profileLink.target = '_blank';
+        profileLink.rel = 'noreferrer';
+        actions.appendChild(profileLink);
+        footer.appendChild(actions);
+
+        document.body.appendChild(overlay);
+
+        const hide = () => closeModal();
+        const onBackdrop = (ev) => {
+          if (ev.target === overlay) hide();
+        };
+        const onKeyDown = (ev) => {
+          if (ev.key === 'Escape') hide();
+        };
+
+        overlay.addEventListener('click', onBackdrop);
+        dialog.addEventListener('click', (ev) => ev.stopPropagation());
+        closeBtn.addEventListener('click', hide);
+        refreshBtn.addEventListener('click', forceSteamRefresh);
+
+        return {
+          show() {
+            overlay.classList.remove('hidden');
+            overlay.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+            document.addEventListener('keydown', onKeyDown);
+            setTimeout(() => closeBtn.focus(), 50);
+          },
+          hide() {
+            overlay.classList.add('hidden');
+            overlay.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+            document.removeEventListener('keydown', onKeyDown);
+          },
+          elements: {
+            avatar,
+            name,
+            persona,
+            meta,
+            badges,
+            details,
+            events: eventsList,
+            status,
+            refreshBtn,
+            profileLink,
+            loading
+          },
+          overlay,
+          destroy() {
+            document.removeEventListener('keydown', onKeyDown);
+            overlay.removeEventListener('click', onBackdrop);
+            closeBtn.removeEventListener('click', hide);
+            refreshBtn.removeEventListener('click', forceSteamRefresh);
+            overlay.remove();
+          }
+        };
+      }
+
       const offLogin = ctx.on?.('auth:login', () => refresh('login'));
       const offServerConnect = ctx.on?.('server:connected', ({ serverId }) => {
         state.serverId = Number(serverId);
@@ -147,6 +586,8 @@
       ctx.onCleanup?.(() => offServerDisconnect?.());
       ctx.onCleanup?.(() => offRefresh?.());
       ctx.onCleanup?.(() => offLogout?.());
+      ctx.onCleanup?.(() => modal?.destroy?.());
+      ctx.onCleanup?.(() => closeModal());
 
       // Initial state when module mounts
       refresh('init');


### PR DESCRIPTION
## Summary
- enable opening a detailed modal for every player in the All Players list with profile, history, and status badges
- add a Force Steam Refresh control in the modal that re-syncs the Steam profile and updates the directory when complete
- refresh the player directory styling for clickable rows and introduce modal overlay styles to fit the dark theme

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d53ae05290833194389f335472e87b