### PR TITLE
Add forced player name controls and improve modal positioning

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -57,6 +57,7 @@ function createApi(pool, dialect) {
         server_id INT NOT NULL,
         steamid VARCHAR(32) NOT NULL,
         display_name VARCHAR(190) NULL,
+        forced_display_name VARCHAR(190) NULL,
         first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_ip VARCHAR(128) NULL,
@@ -76,6 +77,7 @@ function createApi(pool, dialect) {
       await ensureColumn('ALTER TABLE players ADD COLUMN playtime_updated_at TIMESTAMP NULL');
       await ensureColumn('ALTER TABLE server_players ADD COLUMN last_ip VARCHAR(128) NULL');
       await ensureColumn('ALTER TABLE server_players ADD COLUMN last_port INT NULL');
+      await ensureColumn('ALTER TABLE server_players ADD COLUMN forced_display_name VARCHAR(190) NULL');
       await exec(`CREATE TABLE IF NOT EXISTS player_events(
         id INT AUTO_INCREMENT PRIMARY KEY,
         steamid VARCHAR(32) NOT NULL,
@@ -164,14 +166,14 @@ function createApi(pool, dialect) {
       const portNum = Number(port);
       const portValue = Number.isFinite(portNum) ? Math.max(0, Math.trunc(portNum)) : null;
       await exec(`
-        INSERT INTO server_players(server_id, steamid, display_name, first_seen, last_seen, last_ip, last_port)
-        VALUES(?,?,?,?,?,?,?)
+        INSERT INTO server_players(server_id, steamid, display_name, forced_display_name, first_seen, last_seen, last_ip, last_port)
+        VALUES(?,?,?,?,?,?,?,?)
         ON DUPLICATE KEY UPDATE
           display_name=COALESCE(VALUES(display_name), server_players.display_name),
           last_seen=VALUES(last_seen),
           last_ip=COALESCE(VALUES(last_ip), server_players.last_ip),
           last_port=COALESCE(VALUES(last_port), server_players.last_port)
-      `,[serverIdNum,sid,display_name,seen,seen,ipValue,portValue]);
+      `,[serverIdNum,sid,display_name,null,seen,seen,ipValue,portValue]);
     },
     async recordServerPlayerCount({ server_id, player_count, max_players=null, queued=null, sleepers=null, recorded_at=null }){
       const serverIdNum = Number(server_id);
@@ -203,7 +205,7 @@ function createApi(pool, dialect) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
       return await exec(`
-        SELECT sp.server_id, sp.steamid, sp.display_name, sp.first_seen, sp.last_seen,
+        SELECT sp.server_id, sp.steamid, sp.display_name, sp.forced_display_name, sp.first_seen, sp.last_seen,
                sp.last_ip, sp.last_port,
                p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
                p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
@@ -213,6 +215,21 @@ function createApi(pool, dialect) {
         ORDER BY sp.last_seen DESC
         LIMIT ? OFFSET ?
       `,[serverIdNum,limit,offset]);
+    },
+    async setServerPlayerDisplayName({ server_id, steamid, display_name = null }){
+      const serverIdNum = Number(server_id);
+      if (!Number.isFinite(serverIdNum)) return 0;
+      const sid = String(steamid || '').trim();
+      if (!sid) return 0;
+      const value = typeof display_name === 'string' && display_name.trim()
+        ? display_name.trim().slice(0, 190)
+        : null;
+      const result = await exec(`
+        UPDATE server_players
+        SET forced_display_name=?
+        WHERE server_id=? AND steamid=?
+      `,[value,serverIdNum,sid]);
+      return result.affectedRows || 0;
     },
     async addPlayerEvent(ev){ await exec('INSERT INTO player_events(steamid,server_id,event,note) VALUES(?,?,?,?)',[ev.steamid, ev.server_id||null, ev.event, ev.note||null]); },
     async listPlayerEvents(steamid,{limit=100,offset=0}={}){ return await exec('SELECT * FROM player_events WHERE steamid=? ORDER BY id DESC LIMIT ? OFFSET ?',[steamid,limit,offset]); },

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -51,6 +51,7 @@ function createApi(dbh, dialect) {
         server_id INTEGER NOT NULL,
         steamid TEXT NOT NULL,
         display_name TEXT,
+        forced_display_name TEXT,
         first_seen TEXT DEFAULT (datetime('now')),
         last_seen TEXT DEFAULT (datetime('now')),
         last_ip TEXT,
@@ -121,6 +122,7 @@ function createApi(dbh, dialect) {
       };
       await ensureServerPlayerColumn('last_ip', 'last_ip TEXT');
       await ensureServerPlayerColumn('last_port', 'last_port INTEGER');
+      await ensureServerPlayerColumn('forced_display_name', 'forced_display_name TEXT');
     },
     async countUsers(){ const r = await dbh.get('SELECT COUNT(*) c FROM users'); return r.c; },
     async createUser(u){
@@ -191,14 +193,14 @@ function createApi(dbh, dialect) {
       const portNum = Number(port);
       const portValue = Number.isFinite(portNum) ? portNum : null;
       await dbh.run(`
-        INSERT INTO server_players(server_id, steamid, display_name, first_seen, last_seen, last_ip, last_port)
-        VALUES(?,?,?,?,?,?,?)
+        INSERT INTO server_players(server_id, steamid, display_name, forced_display_name, first_seen, last_seen, last_ip, last_port)
+        VALUES(?,?,?,?,?,?,?,?)
         ON CONFLICT(server_id, steamid) DO UPDATE SET
           display_name=COALESCE(excluded.display_name, server_players.display_name),
           last_seen=excluded.last_seen,
           last_ip=COALESCE(excluded.last_ip, server_players.last_ip),
           last_port=COALESCE(excluded.last_port, server_players.last_port)
-      `,[serverIdNum,sid,display_name,seen,seen,ipValue,portValue]);
+      `,[serverIdNum,sid,display_name,null,seen,seen,ipValue,portValue]);
     },
     async recordServerPlayerCount({ server_id, player_count, max_players = null, queued = null, sleepers = null, recorded_at = null }){
       const serverIdNum = Number(server_id);
@@ -229,16 +231,27 @@ function createApi(dbh, dialect) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
       return await dbh.all(`
-        SELECT sp.server_id, sp.steamid, sp.display_name, sp.first_seen, sp.last_seen,
-               sp.last_ip, sp.last_port,
-               p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
-               p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
+        SELECT sp.server_id, sp.steamid, sp.display_name, sp.forced_display_name, sp.first_seen, sp.last_seen,
+                sp.last_ip, sp.last_port,
+                p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
+                p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
         FROM server_players sp
         LEFT JOIN players p ON p.steamid = sp.steamid
         WHERE sp.server_id=?
         ORDER BY sp.last_seen DESC
         LIMIT ? OFFSET ?
       `,[serverIdNum,limit,offset]);
+    },
+    async setServerPlayerDisplayName({ server_id, steamid, display_name = null }){
+      const serverIdNum = Number(server_id);
+      if (!Number.isFinite(serverIdNum)) return 0;
+      const sid = String(steamid || '').trim();
+      if (!sid) return 0;
+      const value = typeof display_name === 'string' && display_name.trim()
+        ? display_name.trim().slice(0, 190)
+        : null;
+      const result = await dbh.run('UPDATE server_players SET forced_display_name=? WHERE server_id=? AND steamid=?',[value,serverIdNum,sid]);
+      return result.changes || 0;
     },
     async addPlayerEvent(ev){ await dbh.run('INSERT INTO player_events(steamid,server_id,event,note) VALUES(?,?,?,?)',[ev.steamid, ev.server_id||null, ev.event, ev.note||null]); },
     async listPlayerEvents(steamid,{limit=100,offset=0}={}){ return await dbh.all('SELECT * FROM player_events WHERE steamid=? ORDER BY id DESC LIMIT ? OFFSET ?',[steamid,limit,offset]); },

--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -110,8 +110,13 @@ main.grid{
 .players-directory{padding:0}
 .players-directory .module-message{padding:24px; text-align:center}
 .player-directory{
-  list-style:none; margin:0; padding:0; display:flex; flex-direction:column;
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
 }
+.player-directory .player-name-row{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
 .player-directory li{
   display:flex; justify-content:space-between; gap:18px; align-items:flex-start;
   padding:16px 18px; border-bottom:1px solid var(--border);
@@ -282,8 +287,8 @@ main.grid{
   position:fixed; inset:0; z-index:90;
   background:rgba(6,9,15,.72);
   backdrop-filter:blur(12px);
-  display:flex; align-items:flex-start; justify-content:center;
-  padding:60px 16px 30px; overflow:auto;
+  display:flex; align-items:center; justify-content:center;
+  padding:40px 16px; overflow:auto;
 }
 .player-modal-backdrop.hidden{display:none}
 .player-modal{


### PR DESCRIPTION
## Summary
- store and expose forced display names for server players, including a PATCH API to update them
- update the players directory modal to show forced names, allow forcing/clearing names, and sync the list after changes
- center the floating player modal and surface forced name indicators in the player list UI

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5465e2b9c8331934a54e3718d87d0