### PR TITLE
Add player population history graph

### DIFF
--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -225,6 +225,47 @@ function createApi(dbh, dialect) {
         timestamp
       ]);
     },
+    async listServerPlayerCounts(serverId, { since = null, until = null, limit = 5000 } = {}){
+      const serverIdNum = Number(serverId);
+      if (!Number.isFinite(serverIdNum)) return [];
+      const conditions = ['server_id=?'];
+      const params = [serverIdNum];
+
+      const normalise = (value) => {
+        if (!value) return null;
+        if (value instanceof Date) {
+          return Number.isNaN(value.getTime()) ? null : value.toISOString();
+        }
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+      };
+
+      const sinceIso = normalise(since);
+      const untilIso = normalise(until);
+      if (sinceIso) {
+        conditions.push('recorded_at >= ?');
+        params.push(sinceIso);
+      }
+      if (untilIso) {
+        conditions.push('recorded_at <= ?');
+        params.push(untilIso);
+      }
+
+      let sql = `
+        SELECT server_id, player_count, max_players, queued, sleepers, recorded_at
+        FROM server_player_counts
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY recorded_at ASC
+      `;
+
+      const maxRows = Number(limit);
+      if (Number.isFinite(maxRows) && maxRows > 0) {
+        sql += ' LIMIT ?';
+        params.push(Math.floor(maxRows));
+      }
+
+      return await dbh.all(sql, params);
+    },
     async listServerPlayers(serverId,{limit=100,offset=0}={}){
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -56,6 +56,174 @@ const STEAM_PROFILE_REFRESH_INTERVAL = Math.max(toInt(process.env.STEAM_PROFILE_
 const STEAM_PLAYTIME_REFRESH_INTERVAL = Math.max(toInt(process.env.STEAM_PLAYTIME_REFRESH_MS || '21600000', 21600000), 3600000);
 const RUST_STEAM_APP_ID = 252490;
 
+const MIN_PLAYER_HISTORY_RANGE_MS = 60 * 60 * 1000; // 1 hour
+const MAX_PLAYER_HISTORY_RANGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const MIN_PLAYER_HISTORY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_PLAYER_HISTORY_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PLAYER_HISTORY_MAX_BUCKETS = 2000;
+
+const DEFAULT_RANGE_INTERVALS = [
+  { maxRange: 6 * 60 * 60 * 1000, interval: 15 * 60 * 1000 },
+  { maxRange: 24 * 60 * 60 * 1000, interval: 60 * 60 * 1000 },
+  { maxRange: 3 * 24 * 60 * 60 * 1000, interval: 3 * 60 * 60 * 1000 },
+  { maxRange: 7 * 24 * 60 * 60 * 1000, interval: 6 * 60 * 60 * 1000 },
+  { maxRange: MAX_PLAYER_HISTORY_RANGE_MS + 1, interval: 24 * 60 * 60 * 1000 }
+];
+
+function clamp(value, min, max) {
+  if (Number.isNaN(value) || !Number.isFinite(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function parseDurationMs(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  const str = String(value).trim();
+  if (!str) return fallback;
+  const match = str.match(/^(-?\d+(?:\.\d+)?)(ms|s|m|h|d)?$/i);
+  if (!match) return fallback;
+  const numeric = Number(match[1]);
+  if (!Number.isFinite(numeric) || numeric <= 0) return fallback;
+  const unit = (match[2] || 'ms').toLowerCase();
+  switch (unit) {
+    case 'ms': return numeric;
+    case 's': return numeric * 1000;
+    case 'm': return numeric * 60 * 1000;
+    case 'h': return numeric * 60 * 60 * 1000;
+    case 'd': return numeric * 24 * 60 * 60 * 1000;
+    default: return fallback;
+  }
+}
+
+function pickDefaultInterval(rangeMs) {
+  for (const entry of DEFAULT_RANGE_INTERVALS) {
+    if (rangeMs <= entry.maxRange) return entry.interval;
+  }
+  return DEFAULT_RANGE_INTERVALS[DEFAULT_RANGE_INTERVALS.length - 1].interval;
+}
+
+function parseTimestamp(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.getTime();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.getTime();
+}
+
+function alignTimestamp(ms, intervalMs, direction = 'floor') {
+  if (!Number.isFinite(ms) || !Number.isFinite(intervalMs) || intervalMs <= 0) return ms;
+  if (direction === 'ceil') {
+    return Math.ceil(ms / intervalMs) * intervalMs;
+  }
+  return Math.floor(ms / intervalMs) * intervalMs;
+}
+
+function buildPlayerHistoryBuckets(rows = [], startMs, endMs, intervalMs) {
+  const bucketMap = new Map();
+  let latestSample = null;
+
+  for (const row of rows) {
+    const timestamp = parseTimestamp(row?.recorded_at ?? row?.recordedAt);
+    if (!Number.isFinite(timestamp)) continue;
+    if (timestamp < startMs || timestamp > endMs) continue;
+    const playerValueRaw = Number(row?.player_count ?? row?.playerCount);
+    const maxPlayersRaw = Number(row?.max_players ?? row?.maxPlayers);
+
+    if (!latestSample || timestamp > latestSample.ts) {
+      latestSample = {
+        ts: timestamp,
+        playerCount: Number.isFinite(playerValueRaw) ? Math.max(0, Math.trunc(playerValueRaw)) : null,
+        maxPlayers: Number.isFinite(maxPlayersRaw) ? Math.max(0, Math.trunc(maxPlayersRaw)) : null
+      };
+    }
+
+    const adjustedTs = timestamp === endMs ? timestamp - 1 : timestamp;
+    const bucketStart = alignTimestamp(adjustedTs, intervalMs, 'floor');
+    if (bucketStart < startMs || bucketStart >= endMs) continue;
+    let bucket = bucketMap.get(bucketStart);
+    if (!bucket) {
+      bucket = { sum: 0, samples: 0, peak: null, maxPlayers: null, queuedMax: null, sleepersMax: null };
+      bucketMap.set(bucketStart, bucket);
+    }
+    if (Number.isFinite(playerValueRaw)) {
+      const playerValue = Math.max(0, playerValueRaw);
+      bucket.sum += playerValue;
+      bucket.samples += 1;
+      bucket.peak = bucket.peak != null ? Math.max(bucket.peak, playerValue) : playerValue;
+    }
+    if (Number.isFinite(maxPlayersRaw)) {
+      const maxValue = Math.max(0, Math.trunc(maxPlayersRaw));
+      bucket.maxPlayers = bucket.maxPlayers != null ? Math.max(bucket.maxPlayers, maxValue) : maxValue;
+    }
+    const queuedRaw = Number(row?.queued ?? row?.queuedPlayers);
+    if (Number.isFinite(queuedRaw)) {
+      const queuedValue = Math.max(0, Math.trunc(queuedRaw));
+      bucket.queuedMax = bucket.queuedMax != null ? Math.max(bucket.queuedMax, queuedValue) : queuedValue;
+    }
+    const sleepersRaw = Number(row?.sleepers ?? row?.sleepersPlayers);
+    if (Number.isFinite(sleepersRaw)) {
+      const sleepersValue = Math.max(0, Math.trunc(sleepersRaw));
+      bucket.sleepersMax = bucket.sleepersMax != null ? Math.max(bucket.sleepersMax, sleepersValue) : sleepersValue;
+    }
+  }
+
+  const buckets = [];
+  let totalSamples = 0;
+  let totalPlayers = 0;
+  let peakPlayers = 0;
+
+  for (let cursor = startMs; cursor < endMs; cursor += intervalMs) {
+    const bucket = bucketMap.get(cursor) || null;
+    let average = null;
+    let samples = 0;
+    let maxPlayers = null;
+    let queued = null;
+    let sleepers = null;
+    if (bucket && bucket.samples > 0) {
+      samples = bucket.samples;
+      average = bucket.sum / bucket.samples;
+      totalSamples += bucket.samples;
+      totalPlayers += bucket.sum;
+      if (bucket.peak != null && bucket.peak > peakPlayers) peakPlayers = bucket.peak;
+      if (bucket.maxPlayers != null) maxPlayers = bucket.maxPlayers;
+      if (bucket.queuedMax != null) queued = bucket.queuedMax;
+      if (bucket.sleepersMax != null) sleepers = bucket.sleepersMax;
+    }
+    buckets.push({
+      timestamp: new Date(cursor).toISOString(),
+      playerCount: Number.isFinite(average) ? Math.round(average * 10) / 10 : null,
+      maxPlayers,
+      queued,
+      sleepers,
+      samples
+    });
+  }
+
+  const summary = {
+    peakPlayers: peakPlayers || null,
+    averagePlayers: totalSamples > 0 ? Math.round((totalPlayers / totalSamples) * 100) / 100 : null,
+    sampleCount: totalSamples,
+    latest: latestSample
+      ? {
+          timestamp: new Date(latestSample.ts).toISOString(),
+          playerCount: latestSample.playerCount,
+          maxPlayers: latestSample.maxPlayers
+        }
+      : null
+  };
+
+  return { buckets, summary };
+}
+
 let lastGlobalMapCacheReset = null;
 
 app.use(express.json({ limit: '25mb' }));
@@ -1490,6 +1658,81 @@ app.get('/api/servers/:id/players', auth, async (req, res) => {
   } catch (err) {
     console.error('listServerPlayers failed', err);
     res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.get('/api/servers/:id/player-counts', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+
+  const now = Date.now();
+  const explicitTo = parseTimestamp(req.query.to) ?? now;
+  const rangeMsRaw = parseDurationMs(req.query.range, 24 * 60 * 60 * 1000);
+  let endMs = Number.isFinite(explicitTo) ? explicitTo : now;
+  let startMs = parseTimestamp(req.query.from);
+
+  const clampedRange = clamp(rangeMsRaw, MIN_PLAYER_HISTORY_RANGE_MS, MAX_PLAYER_HISTORY_RANGE_MS);
+  if (!Number.isFinite(startMs)) startMs = endMs - clampedRange;
+
+  if (endMs - startMs < MIN_PLAYER_HISTORY_RANGE_MS) {
+    startMs = endMs - MIN_PLAYER_HISTORY_RANGE_MS;
+  }
+  if (endMs <= startMs) {
+    endMs = startMs + MIN_PLAYER_HISTORY_RANGE_MS;
+  }
+  if (endMs - startMs > MAX_PLAYER_HISTORY_RANGE_MS) {
+    startMs = endMs - MAX_PLAYER_HISTORY_RANGE_MS;
+  }
+
+  let intervalMs = parseDurationMs(req.query.interval, null);
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    intervalMs = pickDefaultInterval(endMs - startMs);
+  }
+  intervalMs = clamp(intervalMs, MIN_PLAYER_HISTORY_INTERVAL_MS, MAX_PLAYER_HISTORY_INTERVAL_MS);
+
+  let alignedStart = alignTimestamp(startMs, intervalMs, 'floor');
+  let alignedEnd = alignTimestamp(endMs, intervalMs, 'ceil');
+  if (alignedEnd <= alignedStart) alignedEnd = alignedStart + intervalMs;
+
+  const span = alignedEnd - alignedStart;
+  if (span <= 0) {
+    return res.json({
+      serverId: id,
+      from: new Date(alignedStart).toISOString(),
+      to: new Date(alignedEnd).toISOString(),
+      intervalSeconds: Math.round(intervalMs / 1000),
+      buckets: [],
+      summary: { peakPlayers: null, averagePlayers: null, sampleCount: 0, latest: null }
+    });
+  }
+
+  let bucketCount = Math.ceil(span / intervalMs);
+  if (bucketCount > PLAYER_HISTORY_MAX_BUCKETS) {
+    const multiplier = Math.ceil(bucketCount / PLAYER_HISTORY_MAX_BUCKETS);
+    intervalMs = clamp(intervalMs * multiplier, MIN_PLAYER_HISTORY_INTERVAL_MS, MAX_PLAYER_HISTORY_INTERVAL_MS);
+    alignedStart = alignTimestamp(startMs, intervalMs, 'floor');
+    alignedEnd = alignTimestamp(endMs, intervalMs, 'ceil');
+    if (alignedEnd <= alignedStart) alignedEnd = alignedStart + intervalMs;
+  }
+
+  try {
+    const rows = await db.listServerPlayerCounts(id, {
+      since: new Date(alignedStart),
+      until: new Date(alignedEnd),
+      limit: PLAYER_HISTORY_MAX_BUCKETS * 4
+    });
+    const { buckets, summary } = buildPlayerHistoryBuckets(rows, alignedStart, alignedEnd, intervalMs);
+    res.json({
+      serverId: id,
+      from: new Date(alignedStart).toISOString(),
+      to: new Date(alignedEnd).toISOString(),
+      intervalSeconds: Math.round(intervalMs / 1000),
+      buckets,
+      summary
+    });
+  } catch (err) {
+    console.error('player history fetch failed', err);
+    res.status(500).json({ error: 'player_history_failed' });
   }
 });
 

--- a/frontend/assets/modules/players-graph.js
+++ b/frontend/assets/modules/players-graph.js
@@ -1,0 +1,492 @@
+(function(){
+  if (typeof window.registerModule !== 'function') return;
+
+  const RANGE_OPTIONS = [
+    { id: '6h', label: 'Last 6 hours', range: '6h', interval: '15m', rangeMs: 6 * 60 * 60 * 1000 },
+    { id: '12h', label: 'Last 12 hours', range: '12h', interval: '30m', rangeMs: 12 * 60 * 60 * 1000 },
+    { id: '24h', label: 'Last 24 hours', range: '24h', interval: '1h', rangeMs: 24 * 60 * 60 * 1000 },
+    { id: '3d', label: 'Last 3 days', range: '3d', interval: '3h', rangeMs: 3 * 24 * 60 * 60 * 1000 },
+    { id: '7d', label: 'Last 7 days', range: '7d', interval: '6h', rangeMs: 7 * 24 * 60 * 60 * 1000 },
+    { id: '30d', label: 'Last 30 days', range: '30d', interval: '1d', rangeMs: 30 * 24 * 60 * 60 * 1000 }
+  ];
+
+  const DEFAULT_OPTION = RANGE_OPTIONS.find((opt) => opt.id === '24h') || RANGE_OPTIONS[0];
+  const MIN_REFRESH_INTERVAL = 60 * 1000; // 1 minute
+
+  const timeFormatter = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' });
+  const weekdayFormatter = new Intl.DateTimeFormat(undefined, { weekday: 'short' });
+  const dayFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  function optionByKey(key) {
+    return RANGE_OPTIONS.find((opt) => opt.id === key || opt.range === key) || DEFAULT_OPTION;
+  }
+
+  function safeNumber(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+
+  function formatXAxisLabel(timestamp, rangeMs) {
+    const date = new Date(timestamp);
+    if (!Number.isFinite(rangeMs) || rangeMs <= 24 * 60 * 60 * 1000) {
+      return timeFormatter.format(date);
+    }
+    if (rangeMs <= 3 * 24 * 60 * 60 * 1000) {
+      return `${weekdayFormatter.format(date)} ${timeFormatter.format(date)}`;
+    }
+    if (rangeMs <= 7 * 24 * 60 * 60 * 1000) {
+      return `${weekdayFormatter.format(date)} ${timeFormatter.format(date)}`;
+    }
+    return dayFormatter.format(date);
+  }
+
+  function formatPlayerCount(value) {
+    if (!Number.isFinite(value)) return '—';
+    if (Math.abs(value - Math.round(value)) < 0.05) {
+      return Math.round(value).toLocaleString();
+    }
+    return value.toFixed(1);
+  }
+
+  async function defaultApi(path) {
+    const response = await fetch(path, { credentials: 'include' });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(text || `Request failed with status ${response.status}`);
+    }
+    return await response.json();
+  }
+
+  window.registerModule({
+    id: 'players-graph',
+    title: 'Player history',
+    order: 20,
+    setup(ctx){
+      const root = ctx.root || ctx.body || document.createElement('div');
+      root.classList.add('players-graph-container');
+      if (ctx.root && ctx.root.classList) ctx.root.classList.add('players-graph-card');
+      if (ctx.body && ctx.body.classList) ctx.body.classList.add('players-graph-body');
+
+      const container = document.createElement('div');
+      container.className = 'players-graph';
+      ctx.body?.appendChild(container);
+
+      const controls = document.createElement('div');
+      controls.className = 'players-graph-controls';
+      container.appendChild(controls);
+
+      const controlGroup = document.createElement('div');
+      controlGroup.className = 'control-group';
+      controls.appendChild(controlGroup);
+
+      const rangeLabel = document.createElement('label');
+      rangeLabel.textContent = 'Range';
+      rangeLabel.htmlFor = `players-graph-range-${Math.random().toString(36).slice(2, 8)}`;
+      controlGroup.appendChild(rangeLabel);
+
+      const rangeSelect = document.createElement('select');
+      rangeSelect.className = 'players-graph-select';
+      rangeSelect.id = rangeLabel.htmlFor;
+      for (const opt of RANGE_OPTIONS) {
+        const option = document.createElement('option');
+        option.value = opt.id;
+        option.textContent = opt.label;
+        rangeSelect.appendChild(option);
+      }
+      rangeSelect.value = DEFAULT_OPTION.id;
+      controlGroup.appendChild(rangeSelect);
+
+      const refreshBtn = document.createElement('button');
+      refreshBtn.type = 'button';
+      refreshBtn.className = 'btn ghost small';
+      refreshBtn.textContent = 'Refresh';
+      controls.appendChild(refreshBtn);
+
+      const legend = document.createElement('div');
+      legend.className = 'players-graph-legend';
+      legend.innerHTML = '<span><span class="swatch"></span>Players online</span>';
+      controls.appendChild(legend);
+
+      const chartWrap = document.createElement('div');
+      chartWrap.className = 'players-graph-chart';
+      container.appendChild(chartWrap);
+
+      const canvas = document.createElement('canvas');
+      canvas.className = 'players-graph-canvas';
+      chartWrap.appendChild(canvas);
+
+      const summary = document.createElement('div');
+      summary.className = 'players-graph-summary';
+      container.appendChild(summary);
+
+      const message = document.createElement('p');
+      message.className = 'module-message hidden';
+      container.appendChild(message);
+
+      const state = {
+        serverId: null,
+        rangeKey: DEFAULT_OPTION.id,
+        rangeParam: DEFAULT_OPTION.range,
+        intervalParam: DEFAULT_OPTION.interval,
+        rangeMs: DEFAULT_OPTION.rangeMs,
+        buckets: [],
+        summary: null,
+        intervalSeconds: null,
+        isLoading: false,
+        lastFetch: 0,
+        lastError: null
+      };
+
+      function setMessage(text, variant = 'info') {
+        if (!message) return;
+        if (!text) {
+          message.textContent = '';
+          message.classList.add('hidden');
+          message.removeAttribute('data-variant');
+          return;
+        }
+        message.textContent = text;
+        message.classList.remove('hidden');
+        message.dataset.variant = variant;
+      }
+
+      function updateSummary() {
+        if (!summary) return;
+        const parts = [];
+        const option = optionByKey(state.rangeKey);
+        if (option) parts.push(option.label);
+        if (state.summary?.peakPlayers != null) {
+          parts.push(`Peak ${state.summary.peakPlayers}`);
+        }
+        if (state.summary?.averagePlayers != null) {
+          parts.push(`Avg ${formatPlayerCount(state.summary.averagePlayers)}`);
+        }
+        if (state.summary?.latest?.playerCount != null && state.summary?.latest?.timestamp) {
+          const when = new Date(state.summary.latest.timestamp);
+          parts.push(`Latest ${state.summary.latest.playerCount} @ ${dateTimeFormatter.format(when)}`);
+        }
+        summary.textContent = parts.length ? parts.join(' · ') : 'No player history recorded yet.';
+      }
+
+      function renderChart() {
+        const ctx2d = canvas.getContext('2d');
+        if (!ctx2d) return;
+        const width = Math.max(chartWrap.clientWidth || container.clientWidth || 600, 200);
+        const height = 260;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.round(width * dpr);
+        canvas.height = Math.round(height * dpr);
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+        ctx2d.save();
+        ctx2d.scale(dpr, dpr);
+        ctx2d.clearRect(0, 0, width, height);
+
+        const padding = { left: 56, right: 20, top: 18, bottom: 40 };
+        const chartWidth = Math.max(width - padding.left - padding.right, 50);
+        const chartHeight = Math.max(height - padding.top - padding.bottom, 50);
+        const originX = padding.left;
+        const originY = padding.top + chartHeight;
+
+        ctx2d.fillStyle = 'rgba(15, 23, 42, 0.55)';
+        ctx2d.strokeStyle = 'rgba(148, 163, 184, 0.22)';
+        ctx2d.lineWidth = 1;
+        const backdropX = padding.left - 24;
+        const backdropY = padding.top - 16;
+        const backdropW = chartWidth + 48;
+        const backdropH = chartHeight + 32;
+        if (typeof ctx2d.roundRect === 'function') {
+          ctx2d.beginPath();
+          ctx2d.roundRect(backdropX, backdropY, backdropW, backdropH, 12);
+          ctx2d.fill();
+          ctx2d.stroke();
+        } else {
+          ctx2d.fillRect(backdropX, backdropY, backdropW, backdropH);
+          ctx2d.strokeRect(backdropX, backdropY, backdropW, backdropH);
+        }
+
+        const values = [];
+        const maxPlayersValues = [];
+        state.buckets.forEach((bucket, index) => {
+          const value = safeNumber(bucket?.playerCount);
+          if (value != null) values.push({ index, value });
+          const mp = safeNumber(bucket?.maxPlayers);
+          if (mp != null) maxPlayersValues.push(mp);
+        });
+
+        const hasData = values.length > 0;
+        const baseMax = values.reduce((max, point) => Math.max(max, point.value), 0);
+        const maxPlayers = maxPlayersValues.reduce((max, val) => Math.max(max, val), 0);
+        const upperBound = Math.max(baseMax, maxPlayers, 10);
+
+        const yScale = chartHeight / (upperBound || 1);
+        const xForIndex = (index) => {
+          if (state.buckets.length <= 1) return originX + chartWidth / 2;
+          return originX + (index / (state.buckets.length - 1)) * chartWidth;
+        };
+        const yForValue = (value) => originY - value * yScale;
+
+        // Grid lines
+        ctx2d.strokeStyle = 'rgba(148, 163, 184, 0.25)';
+        ctx2d.fillStyle = 'rgba(148, 163, 184, 0.65)';
+        ctx2d.font = '12px "Inter", "Segoe UI", sans-serif';
+        ctx2d.textAlign = 'right';
+        ctx2d.textBaseline = 'middle';
+        const gridLines = 4;
+        for (let i = 0; i <= gridLines; i += 1) {
+          const fraction = i / gridLines;
+          const value = upperBound * fraction;
+          const y = yForValue(value);
+          ctx2d.beginPath();
+          ctx2d.moveTo(originX, y);
+          ctx2d.lineTo(originX + chartWidth, y);
+          ctx2d.stroke();
+          ctx2d.fillText(Math.round(value).toLocaleString(), originX - 8, y);
+        }
+
+        // X-axis labels
+        ctx2d.textAlign = 'center';
+        ctx2d.textBaseline = 'top';
+        const rangeMs = optionByKey(state.rangeKey)?.rangeMs || DEFAULT_OPTION.rangeMs;
+        if (state.buckets.length) {
+          const steps = Math.min(5, state.buckets.length);
+          const labelIndices = new Set();
+          if (steps === 1) {
+            labelIndices.add(0);
+          } else {
+            for (let s = 0; s < steps; s += 1) {
+              const ratio = s / (steps - 1);
+              const idx = Math.round(ratio * (state.buckets.length - 1));
+              labelIndices.add(idx);
+            }
+          }
+          ctx2d.fillStyle = 'rgba(148, 163, 184, 0.85)';
+          ctx2d.font = '12px "Inter", "Segoe UI", sans-serif';
+          labelIndices.forEach((idx) => {
+            const bucket = state.buckets[idx];
+            if (!bucket) return;
+            const label = formatXAxisLabel(bucket.timestamp, rangeMs);
+            const x = xForIndex(idx);
+            ctx2d.fillText(label, x, originY + 8);
+          });
+        }
+
+        if (hasData) {
+          ctx2d.lineWidth = 2;
+          ctx2d.strokeStyle = '#38bdf8';
+          ctx2d.fillStyle = 'rgba(56, 189, 248, 0.18)';
+
+          ctx2d.beginPath();
+          let drawing = false;
+          state.buckets.forEach((bucket, idx) => {
+            const value = safeNumber(bucket?.playerCount);
+            if (value == null) {
+              drawing = false;
+              return;
+            }
+            const x = xForIndex(idx);
+            const y = yForValue(value);
+            if (!drawing) {
+              ctx2d.moveTo(x, y);
+              drawing = true;
+            } else {
+              ctx2d.lineTo(x, y);
+            }
+          });
+          ctx2d.stroke();
+
+          // Fill under line
+          ctx2d.beginPath();
+          drawing = false;
+          state.buckets.forEach((bucket, idx) => {
+            const value = safeNumber(bucket?.playerCount);
+            if (value == null) {
+              if (drawing) {
+                const x = xForIndex(idx - 1);
+                ctx2d.lineTo(x, originY);
+                ctx2d.closePath();
+                ctx2d.fill();
+                drawing = false;
+                ctx2d.beginPath();
+              }
+              return;
+            }
+            const x = xForIndex(idx);
+            const y = yForValue(value);
+            if (!drawing) {
+              ctx2d.moveTo(x, originY);
+              ctx2d.lineTo(x, y);
+              drawing = true;
+            } else {
+              ctx2d.lineTo(x, y);
+            }
+          });
+          if (drawing) {
+            const lastX = xForIndex(state.buckets.length - 1);
+            ctx2d.lineTo(lastX, originY);
+            ctx2d.closePath();
+            ctx2d.fill();
+          }
+
+          // Highlight latest point
+          if (state.summary?.latest?.playerCount != null) {
+            const latestIndex = [...state.buckets].reverse().findIndex((bucket) => safeNumber(bucket?.playerCount) != null);
+            if (latestIndex >= 0) {
+              const idx = state.buckets.length - 1 - latestIndex;
+              const value = safeNumber(state.buckets[idx]?.playerCount);
+              if (value != null) {
+                const x = xForIndex(idx);
+                const y = yForValue(value);
+                ctx2d.fillStyle = '#38bdf8';
+                ctx2d.beginPath();
+                ctx2d.arc(x, y, 4, 0, Math.PI * 2);
+                ctx2d.fill();
+              }
+            }
+          }
+        } else {
+          ctx2d.fillStyle = 'rgba(148, 163, 184, 0.65)';
+          ctx2d.font = '13px "Inter", "Segoe UI", sans-serif';
+          ctx2d.textAlign = 'center';
+          ctx2d.textBaseline = 'middle';
+          const text = state.serverId
+            ? 'No player data recorded for this period.'
+            : 'Select a server to view player history.';
+          ctx2d.fillText(text, originX + chartWidth / 2, padding.top + chartHeight / 2);
+        }
+
+        ctx2d.restore();
+      }
+
+      function shouldThrottle() {
+        return Date.now() - state.lastFetch < MIN_REFRESH_INTERVAL;
+      }
+
+      async function fetchHistory(reason = 'manual') {
+        if (state.isLoading) return;
+        if (!Number.isFinite(state.serverId)) {
+          state.buckets = [];
+          state.summary = null;
+          setMessage('Select a server to view player history.');
+          renderChart();
+          updateSummary();
+          return;
+        }
+        state.isLoading = true;
+        state.lastError = null;
+        rangeSelect.disabled = true;
+        refreshBtn.disabled = true;
+        setMessage('Loading player history…');
+        try {
+          const params = new URLSearchParams({ range: state.rangeParam, interval: state.intervalParam });
+          const result = await (typeof ctx.api === 'function' ? ctx.api(`/api/servers/${state.serverId}/player-counts?${params}`) : defaultApi(`/api/servers/${state.serverId}/player-counts?${params}`));
+          state.buckets = Array.isArray(result?.buckets) ? result.buckets : [];
+          state.summary = result?.summary || null;
+          state.intervalSeconds = safeNumber(result?.intervalSeconds);
+          state.lastFetch = Date.now();
+          if (!state.buckets.some((bucket) => safeNumber(bucket?.playerCount) != null)) {
+            setMessage('No player data recorded for this range yet.');
+          } else {
+            setMessage('');
+          }
+          renderChart();
+        } catch (err) {
+          state.lastError = err;
+          const description = ctx.describeError?.(err) || err?.message || 'Unknown error';
+          setMessage(`Unable to load player history: ${description}`, 'error');
+          state.buckets = [];
+          state.summary = null;
+          ctx.log?.(`players-graph error (${reason}): ${description}`);
+          renderChart();
+        } finally {
+          state.isLoading = false;
+          rangeSelect.disabled = false;
+          refreshBtn.disabled = false;
+          updateSummary();
+        }
+      }
+
+      function requestRefresh(reason = 'auto') {
+        if (shouldThrottle()) return;
+        fetchHistory(reason);
+      }
+
+      rangeSelect.addEventListener('change', () => {
+        const nextOption = optionByKey(rangeSelect.value);
+        state.rangeKey = nextOption.id;
+        state.rangeParam = nextOption.range;
+        state.intervalParam = nextOption.interval;
+        state.rangeMs = nextOption.rangeMs;
+        fetchHistory('range-change');
+      });
+
+      refreshBtn.addEventListener('click', () => fetchHistory('manual'));
+
+      const resizeObserver = typeof ResizeObserver === 'function'
+        ? new ResizeObserver(() => renderChart())
+        : null;
+      if (resizeObserver) resizeObserver.observe(chartWrap);
+      else window.addEventListener('resize', renderChart);
+
+      ctx.onCleanup?.(() => {
+        if (resizeObserver) resizeObserver.disconnect();
+        else window.removeEventListener('resize', renderChart);
+      });
+
+      const offServerConnect = ctx.on?.('server:connected', ({ serverId }) => {
+        if (!Number.isFinite(Number(serverId))) return;
+        state.serverId = Number(serverId);
+        fetchHistory('server-connect');
+      });
+
+      const offServerDisconnect = ctx.on?.('server:disconnected', ({ serverId }) => {
+        if (!Number.isFinite(Number(serverId)) || Number(serverId) !== state.serverId) return;
+        state.serverId = null;
+        state.buckets = [];
+        state.summary = null;
+        setMessage('Connect to a server to view player history.');
+        renderChart();
+        updateSummary();
+      });
+
+      const offLogout = ctx.on?.('auth:logout', () => {
+        state.serverId = null;
+        state.buckets = [];
+        state.summary = null;
+        setMessage('Sign in to view player history.');
+        renderChart();
+        updateSummary();
+      });
+
+      const offPlayersRefresh = ctx.on?.('players:refresh', ({ serverId }) => {
+        if (Number.isFinite(Number(serverId)) && Number(serverId) !== state.serverId) return;
+        requestRefresh('players-refresh');
+      });
+
+      ctx.onCleanup?.(() => offServerConnect?.());
+      ctx.onCleanup?.(() => offServerDisconnect?.());
+      ctx.onCleanup?.(() => offLogout?.());
+      ctx.onCleanup?.(() => offPlayersRefresh?.());
+
+      const initialState = ctx.getState?.();
+      const initialServer = Number(initialState?.currentServerId);
+      if (Number.isFinite(initialServer)) {
+        state.serverId = initialServer;
+        fetchHistory('init');
+      } else {
+        setMessage('Select a server to view player history.');
+        renderChart();
+        updateSummary();
+      }
+
+      // Initial draw to ensure canvas has base styling even before data loads
+      renderChart();
+    }
+  });
+})();

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -910,6 +910,105 @@ button.menu-tab.active {
   gap: 18px;
 }
 
+.players-graph-card .card-body,
+.players-graph-body {
+  padding: 18px 22px;
+}
+
+.players-graph {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.players-graph-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.players-graph-controls .control-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.players-graph-controls label {
+  font-size: 0.85rem;
+  color: var(--muted-strong);
+}
+
+.players-graph-select {
+  appearance: none;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  padding: 6px 32px 6px 12px;
+  font-size: 0.92rem;
+  line-height: 1.3;
+  position: relative;
+  min-width: 180px;
+}
+
+.players-graph-select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 2px;
+}
+
+.players-graph-chart {
+  width: 100%;
+  position: relative;
+}
+
+.players-graph-canvas {
+  width: 100%;
+  height: 260px;
+  display: block;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.players-graph-summary {
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.players-graph-summary strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.players-graph-legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--muted-strong);
+}
+
+.players-graph-legend .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+  background: #38bdf8;
+  box-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
+  margin-right: 6px;
+}
+
+.players-graph .module-message {
+  border-style: solid;
+  padding: 18px;
+}
+
 .module-message {
   margin: 0;
   padding: 26px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -155,6 +155,16 @@
 
         <div class="workspace-views">
           <section id="workspaceViewPlayers" class="workspace-view active" data-view="players" aria-hidden="false">
+            <div class="card graph-card module-hidden" data-module-card="players-graph">
+              <div class="card-header">
+                <div class="card-title-group">
+                  <h3><span data-module-title>Player History</span></h3>
+                  <div class="module-actions" data-module-actions></div>
+                </div>
+              </div>
+              <div class="module-body" data-module-slot="players-graph"></div>
+            </div>
+
             <div class="card players-card" data-module-card="live-players">
               <div class="card-header">
                 <div class="card-title-group">
@@ -351,6 +361,7 @@
   </div>
 
   <script src="assets/modules/module-loader.js"></script>
+  <script src="assets/modules/players-graph.js"></script>
   <script src="assets/modules/live-players.js"></script>
   <script src="assets/modules/players.js"></script>
   <script src="assets/modules/map.js"></script>

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="stylesheet" href="/assets/css/dark-theme.css" />
     <script defer src="/assets/modules/module-loader.js"></script>
+    <script defer src="/assets/modules/players-graph.js"></script>
     <script defer src="/assets/modules/live-console.js"></script>
     <script defer src="/assets/modules/map.js"></script>
     <script defer src="/assets/modules/live-players.js"></script>
@@ -34,6 +35,16 @@
     </nav>
 
     <section class="view-panel active" data-view="players">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Player History</div>
+        </div>
+        <div class="card-body players-graph-body">
+          <div class="players-graph" data-module="players-graph"
+               data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+      </div>
+
       <div class="card full-width">
         <div class="card-head">
           <div class="card-title">Current Players <span id="player-count" class="muted">(0)</span></div>


### PR DESCRIPTION
## Summary
- add database helpers and an API endpoint to bucket historical player counts for a server
- add a players graph module with a selectable time range and responsive canvas rendering
- surface the new graph card in the control panel UI and apply supporting styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d54778365c833188b624a64831eefd