### PR TITLE
Add Discord integration management UI and backend support

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -115,6 +115,15 @@ function createApi(pool, dialect) {
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         CONSTRAINT fk_server_maps FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
       ) ENGINE=InnoDB;`);
+      await exec(`CREATE TABLE IF NOT EXISTS server_discord_integrations(
+        server_id INT PRIMARY KEY,
+        bot_token TEXT NULL,
+        guild_id VARCHAR(64) NULL,
+        channel_id VARCHAR(64) NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        CONSTRAINT fk_server_discord FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB;`);
     },
     async countUsers(){ const r = await exec('SELECT COUNT(*) c FROM users'); const row = Array.isArray(r)?r[0]:r; return row.c ?? row['COUNT(*)']; },
     async createUser(u){
@@ -244,6 +253,27 @@ function createApi(pool, dialect) {
       }
       const rows = await exec('SELECT COUNT(*) c FROM server_maps WHERE image_path=?', [imagePath]);
       return rows?.[0]?.c ? Number(rows[0].c) : 0;
+    },
+    async getServerDiscordIntegration(serverId){
+      const rows = await exec('SELECT * FROM server_discord_integrations WHERE server_id=?',[serverId]);
+      return rows?.[0] ?? null;
+    },
+    async saveServerDiscordIntegration(serverId,{ bot_token=null,guild_id=null,channel_id=null }){
+      await exec(`
+        INSERT INTO server_discord_integrations(server_id, bot_token, guild_id, channel_id)
+        VALUES(?,?,?,?)
+        ON DUPLICATE KEY UPDATE
+          bot_token=VALUES(bot_token),
+          guild_id=VALUES(guild_id),
+          channel_id=VALUES(channel_id)
+      `,[serverId, bot_token, guild_id, channel_id]);
+    },
+    async deleteServerDiscordIntegration(serverId){
+      const result = await exec('DELETE FROM server_discord_integrations WHERE server_id=?',[serverId]);
+      if (result == null) return 0;
+      if (typeof result.affectedRows === 'number') return result.affectedRows;
+      if (Array.isArray(result) && typeof result[0]?.affectedRows === 'number') return result[0].affectedRows;
+      return 0;
     }
   };
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -911,6 +911,56 @@ function toServerId(value) {
   return Number.isFinite(id) ? id : null;
 }
 
+function sanitizeDiscordToken(value, maxLength = 256) {
+  if (value == null) return '';
+  const text = String(value).trim();
+  if (!text) return '';
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return text;
+  return text.slice(0, maxLength);
+}
+
+function sanitizeDiscordSnowflake(value, maxLength = 64) {
+  if (value == null) return '';
+  const digits = String(value).replace(/[^0-9]/g, '');
+  if (!digits) return '';
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return digits;
+  return digits.slice(0, maxLength);
+}
+
+function projectDiscordIntegration(row) {
+  if (!row || typeof row !== 'object') return null;
+  const serverId = Number(row.server_id ?? row.serverId);
+  return {
+    serverId: Number.isFinite(serverId) ? serverId : null,
+    guildId: row.guild_id || row.guildId || null,
+    channelId: row.channel_id || row.channelId || null,
+    createdAt: row.created_at || row.createdAt || null,
+    updatedAt: row.updated_at || row.updatedAt || null,
+    hasToken: Boolean(row.bot_token)
+  };
+}
+
+function describeDiscordStatus(serverId) {
+  const numericId = Number(serverId);
+  const status = Number.isFinite(numericId) ? statusMap.get(numericId) : null;
+  const details = status?.details || {};
+  const playersOnline = Number(details?.players?.online);
+  const maxPlayers = Number(details?.players?.max);
+  const joiningRaw = Number(details?.joining);
+  const serverOnline = Boolean(status?.ok);
+  return {
+    serverOnline,
+    players: {
+      current: Number.isFinite(playersOnline) ? playersOnline : 0,
+      max: Number.isFinite(maxPlayers) ? maxPlayers : null
+    },
+    joining: Number.isFinite(joiningRaw) ? Math.max(0, joiningRaw) : 0,
+    presence: serverOnline ? 'online' : 'dnd',
+    presenceLabel: serverOnline ? 'Online' : 'Do Not Disturb',
+    lastCheck: status?.lastCheck || null
+  };
+}
+
 rconEventBus.on('monitor_status', (serverId, payload) => {
   const id = toServerId(serverId);
   if (id == null) return;
@@ -1230,6 +1280,84 @@ app.get('/api/servers/:id/status', auth, (req, res) => {
   const status = statusMap.get(id);
   if (!status) return res.status(404).json({ error: 'not_found' });
   res.json(status);
+});
+
+app.get('/api/servers/:id/discord', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (typeof db.getServerDiscordIntegration !== 'function') {
+    return res.status(501).json({ error: 'not_supported' });
+  }
+  try {
+    const server = await db.getServer(id);
+    if (!server) return res.status(404).json({ error: 'not_found' });
+    const integration = await db.getServerDiscordIntegration(id);
+    res.json({
+      integration: projectDiscordIntegration(integration),
+      status: describeDiscordStatus(id)
+    });
+  } catch (err) {
+    console.error('failed to load discord integration', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/servers/:id/discord', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (typeof db.saveServerDiscordIntegration !== 'function' || typeof db.getServerDiscordIntegration !== 'function') {
+    return res.status(501).json({ error: 'not_supported' });
+  }
+  try {
+    const server = await db.getServer(id);
+    if (!server) return res.status(404).json({ error: 'not_found' });
+    const existing = await db.getServerDiscordIntegration(id);
+    const body = req.body || {};
+    const guildId = sanitizeDiscordSnowflake(body.guildId ?? body.guild_id);
+    const channelId = sanitizeDiscordSnowflake(body.channelId ?? body.channel_id);
+    const tokenInput = sanitizeDiscordToken(body.botToken ?? body.bot_token);
+    if (!guildId || !channelId) return res.status(400).json({ error: 'missing_fields' });
+    let botToken = tokenInput;
+    if (!botToken) {
+      const existingToken = existing?.bot_token;
+      if (existingToken) botToken = existingToken;
+      else return res.status(400).json({ error: 'missing_bot_token' });
+    }
+    await db.saveServerDiscordIntegration(id, {
+      bot_token: botToken,
+      guild_id: guildId,
+      channel_id: channelId
+    });
+    const integration = await db.getServerDiscordIntegration(id);
+    res.json({
+      integration: projectDiscordIntegration(integration),
+      status: describeDiscordStatus(id)
+    });
+  } catch (err) {
+    console.error('failed to save discord integration', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.delete('/api/servers/:id/discord', auth, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  if (typeof db.deleteServerDiscordIntegration !== 'function') {
+    return res.status(501).json({ error: 'not_supported' });
+  }
+  try {
+    const server = await db.getServer(id);
+    if (!server) return res.status(404).json({ error: 'not_found' });
+    const removed = await db.deleteServerDiscordIntegration(id);
+    res.json({
+      removed: Number(removed) > 0,
+      integration: null,
+      status: describeDiscordStatus(id)
+    });
+  } catch (err) {
+    console.error('failed to delete discord integration', err);
+    res.status(500).json({ error: 'db_error' });
+  }
 });
 
 app.post('/api/servers', auth, async (req, res) => {

--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -46,6 +46,7 @@ body.modal-open{overflow:hidden}
   border:1px solid var(--border); background:var(--surface)
 }
 .badge.success{background:rgba(34,197,94,.12); color:#a3ffbf; border-color:rgba(34,197,94,.25)}
+.badge.offline{background:rgba(239,68,68,.2); color:#fecaca; border-color:rgba(239,68,68,.45)}
 
 .btn{
   appearance:none; border:1px solid var(--border); border-radius:10px;
@@ -235,6 +236,9 @@ main.grid{
 .map-upload .notice{padding:10px 12px; border-radius:10px; font-size:13px}
 .map-upload .notice.error{background:rgba(239,68,68,.18); color:#fecaca; border:1px solid rgba(239,68,68,.4)}
 .map-upload .notice.success{background:rgba(34,197,94,.18); color:#bbf7d0; border:1px solid rgba(34,197,94,.35)}
+.discord-notice{padding:10px 12px; border-radius:10px; font-size:.85rem; background:rgba(59,130,246,.16); color:#bfdbfe; border:1px solid rgba(59,130,246,.35)}
+.discord-notice.error{background:rgba(239,68,68,.18); color:#fecaca; border-color:rgba(239,68,68,.4)}
+.discord-notice.success{background:rgba(34,197,94,.18); color:#bbf7d0; border-color:rgba(34,197,94,.35)}
 
 .players-list{max-height:260px; overflow:auto}
 .live-players-list{display:flex; flex-direction:column}
@@ -262,6 +266,21 @@ main.grid{
 .badge.gameban{background:rgba(249,115,22,.2); color:#fed7aa; border-color:rgba(249,115,22,.45)}
 .badge.country{background:rgba(59,130,246,.2); color:#bfdbfe; border-color:rgba(59,130,246,.45)}
 .badge.warn{background:rgba(245,158,11,.18); color:#fde68a; border-color:rgba(245,158,11,.4)}
+.discord-settings-grid{display:grid; gap:24px; align-items:start}
+@media(min-width:960px){.discord-settings-grid{grid-template-columns:1fr 1fr}}
+.section-title{margin:0 0 12px; font-size:.85rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted)}
+.discord-status-summary{display:flex; flex-wrap:wrap; gap:16px; align-items:stretch}
+.discord-stat{background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius); padding:14px 16px; min-width:160px; flex:1 1 140px}
+.discord-stat .label{display:block; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); margin-bottom:6px}
+.discord-stat .value{font-size:1.6rem; font-weight:700}
+.discord-last-check{margin:12px 0 0; font-size:.85rem; color:var(--muted)}
+.discord-form{display:grid; gap:16px; max-width:420px}
+.discord-form .field{display:flex; flex-direction:column; gap:6px}
+.discord-form .field-label{font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted)}
+.discord-form input{background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius-sm); padding:10px 12px; color:var(--text); font-size:.95rem}
+.discord-form input:focus{outline:2px solid rgba(59,130,246,.35); outline-offset:2px}
+.discord-form .form-actions{display:flex; gap:12px; flex-wrap:wrap}
+.discord-form .form-actions .btn{min-width:150px}
 .player-row{
   display:flex; align-items:center; justify-content:space-between;
   padding:12px 14px; border-bottom:1px solid var(--border);

--- a/frontend/assets/js/server-settings.js
+++ b/frontend/assets/js/server-settings.js
@@ -1,0 +1,243 @@
+(() => {
+  const settingsRoot = document.getElementById('discord-settings');
+  const serverId = document.body?.dataset?.serverId;
+  if (!settingsRoot || !serverId) return;
+
+  const API_BASE = typeof window !== 'undefined' && window.API_BASE
+    ? String(window.API_BASE).replace(/\/+$/g, '')
+    : '';
+  const endpoint = `${API_BASE}/api/servers/${encodeURIComponent(serverId)}/discord`;
+
+  const badgeEl = document.getElementById('discord-bot-status');
+  const playersEl = document.getElementById('discord-current-players');
+  const maxPlayersEl = document.getElementById('discord-max-players');
+  const joiningEl = document.getElementById('discord-joining');
+  const lastCheckEl = document.getElementById('discord-last-check');
+  const form = document.getElementById('discord-form');
+  const tokenInput = document.getElementById('discord-bot-token');
+  const guildInput = document.getElementById('discord-guild-id');
+  const channelInput = document.getElementById('discord-channel-id');
+  const removeBtn = document.getElementById('discord-remove');
+  const noticeEl = document.getElementById('discord-notice');
+
+  const state = {
+    integration: null,
+    pollTimer: null
+  };
+
+  function buildError(message, code) {
+    const err = new Error(message || code || 'api_error');
+    if (code) err.code = code;
+    return err;
+  }
+
+  function setNotice(message, variant = 'info') {
+    if (!noticeEl) return;
+    noticeEl.textContent = message || '';
+    noticeEl.classList.remove('hidden', 'error', 'success');
+    if (variant === 'error') noticeEl.classList.add('error');
+    else if (variant === 'success') noticeEl.classList.add('success');
+  }
+
+  function clearNotice() {
+    if (!noticeEl) return;
+    noticeEl.textContent = '';
+    noticeEl.classList.add('hidden');
+    noticeEl.classList.remove('error', 'success');
+  }
+
+  function disableForm(disabled) {
+    if (!form) return;
+    const elements = form.querySelectorAll('input, button');
+    elements.forEach((el) => { el.disabled = !!disabled; });
+    if (removeBtn) removeBtn.disabled = !!disabled || !state.integration;
+  }
+
+  function updateBadge(presenceLabel, presence) {
+    if (!badgeEl) return;
+    const status = presence === 'online' ? 'online' : 'offline';
+    badgeEl.textContent = presenceLabel || (status === 'online' ? 'Online' : 'Do Not Disturb');
+    badgeEl.classList.remove('success', 'offline');
+    if (status === 'online') badgeEl.classList.add('success');
+    else badgeEl.classList.add('offline');
+  }
+
+  function updateStatusView(status = {}) {
+    const players = Number(status?.players?.current);
+    const maxPlayers = Number(status?.players?.max);
+    const joining = Number(status?.joining);
+    if (playersEl) playersEl.textContent = Number.isFinite(players) && players >= 0 ? String(players) : '0';
+    if (maxPlayersEl) {
+      if (Number.isFinite(maxPlayers) && maxPlayers >= 0) maxPlayersEl.textContent = String(maxPlayers);
+      else maxPlayersEl.textContent = '—';
+    }
+    if (joiningEl) joiningEl.textContent = Number.isFinite(joining) && joining >= 0 ? String(joining) : '0';
+    updateBadge(status?.presenceLabel, status?.presence);
+    if (lastCheckEl) {
+      const value = status?.lastCheck ? new Date(status.lastCheck) : null;
+      if (value && !Number.isNaN(value.getTime())) {
+        lastCheckEl.textContent = `Last check: ${value.toLocaleString()}`;
+      } else {
+        lastCheckEl.textContent = 'Last check: —';
+      }
+    }
+  }
+
+  function applyIntegration(integration) {
+    state.integration = integration;
+    if (guildInput) guildInput.value = integration?.guildId || '';
+    if (channelInput) channelInput.value = integration?.channelId || '';
+    if (tokenInput) {
+      tokenInput.value = '';
+      tokenInput.placeholder = integration?.hasToken
+        ? 'Token stored — enter to replace'
+        : 'Paste bot token';
+    }
+    if (removeBtn) removeBtn.disabled = !integration;
+  }
+
+  function describeError(code) {
+    switch (code) {
+      case 'missing_fields':
+        return 'Provide both the guild and channel IDs.';
+      case 'missing_bot_token':
+        return 'Add the Discord bot token before saving.';
+      case 'unauthorized':
+        return 'Sign in to configure Discord integration.';
+      case 'not_found':
+        return 'This server could not be found.';
+      case 'not_supported':
+        return 'Discord integration is not enabled on this server.';
+      case 'network_error':
+        return 'Unable to reach the server. Check your connection.';
+      case 'db_error':
+        return 'The server could not save the Discord settings.';
+      default:
+        return 'An unexpected error occurred while updating Discord integration.';
+    }
+  }
+
+  async function apiRequest(method = 'GET', body = null) {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw buildError('unauthorized', 'unauthorized');
+    }
+    const headers = { 'Authorization': 'Bearer ' + token };
+    const options = { method, headers };
+    if (body !== null && body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      options.body = JSON.stringify(body);
+    }
+    let response;
+    try {
+      response = await fetch(endpoint, options);
+    } catch {
+      throw buildError('network_error', 'network_error');
+    }
+    let payload = null;
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      try { payload = await response.json(); }
+      catch { payload = null; }
+    }
+    if (response.status === 401) {
+      throw buildError('unauthorized', 'unauthorized');
+    }
+    if (!response.ok) {
+      const code = payload?.error || 'api_error';
+      const err = buildError(code, code);
+      err.status = response.status;
+      err.payload = payload;
+      throw err;
+    }
+    return payload || {};
+  }
+
+  function handleError(err, { silent = false } = {}) {
+    const code = err?.code || err?.message || 'api_error';
+    if (code === 'unauthorized') {
+      disableForm(true);
+      if (!silent) setNotice(describeError(code), 'error');
+      return;
+    }
+    if (code === 'network_error' || code === 'not_found' || code === 'not_supported' || code === 'db_error' || code === 'missing_fields' || code === 'missing_bot_token') {
+      if (!silent) setNotice(describeError(code), 'error');
+      if (code === 'not_found' || code === 'not_supported') disableForm(true);
+      return;
+    }
+    if (!silent) setNotice(describeError(code), 'error');
+  }
+
+  async function refresh(options = {}) {
+    const { silent = false } = options;
+    try {
+      if (!silent) setNotice('Loading Discord integration…');
+      const data = await apiRequest('GET');
+      applyIntegration(data.integration || null);
+      updateStatusView(data.status || {});
+      disableForm(false);
+      clearNotice();
+    } catch (err) {
+      handleError(err, { silent });
+    }
+  }
+
+  async function saveIntegration(event) {
+    event?.preventDefault();
+    if (!form) return;
+    const payload = {
+      botToken: tokenInput?.value?.trim() || '',
+      guildId: guildInput?.value?.trim() || '',
+      channelId: channelInput?.value?.trim() || ''
+    };
+    disableForm(true);
+    setNotice('Saving Discord integration…');
+    try {
+      const data = await apiRequest('POST', payload);
+      applyIntegration(data.integration || null);
+      updateStatusView(data.status || {});
+      if (tokenInput) tokenInput.value = '';
+      setNotice('Discord integration saved.', 'success');
+      disableForm(false);
+    } catch (err) {
+      disableForm(false);
+      handleError(err);
+    }
+  }
+
+  async function removeIntegration() {
+    if (!state.integration) {
+      setNotice('No Discord integration is configured for this server.', 'error');
+      return;
+    }
+    disableForm(true);
+    setNotice('Removing Discord integration…');
+    try {
+      const data = await apiRequest('DELETE');
+      applyIntegration(null);
+      updateStatusView(data.status || {});
+      setNotice('Discord integration removed.', 'success');
+      disableForm(false);
+    } catch (err) {
+      disableForm(false);
+      handleError(err);
+    }
+  }
+
+  function schedulePolling() {
+    if (state.pollTimer) clearInterval(state.pollTimer);
+    state.pollTimer = setInterval(() => {
+      refresh({ silent: true });
+    }, 15000);
+  }
+
+  if (form) form.addEventListener('submit', saveIntegration);
+  if (removeBtn) removeBtn.addEventListener('click', removeIntegration);
+  window.addEventListener('beforeunload', () => {
+    if (state.pollTimer) clearInterval(state.pollTimer);
+  });
+
+  refresh().finally(() => {
+    schedulePolling();
+  });
+})();

--- a/frontend/pages/server.html
+++ b/frontend/pages/server.html
@@ -12,7 +12,7 @@
     <script defer src="/assets/modules/players.js"></script>
     <script defer src="/assets/js/panel-shell.js"></script>
   </head>
-<body class="app">
+<body class="app" data-server-id="__SERVER_ID__">
   <header class="topbar">
     <a class="back" href="/servers">← Back to Servers</a>
     <div class="server-title">
@@ -29,6 +29,7 @@
     <nav class="server-menu" aria-label="Server sections">
       <button class="menu-tab active" type="button" data-target="players">Players</button>
       <button class="menu-tab" type="button" data-target="map">Map</button>
+      <button class="menu-tab" type="button" data-target="settings">Settings</button>
       <button class="menu-tab" type="button" data-target="console">Console</button>
       <button class="menu-tab" type="button" data-target="dashboard">Dashboard</button>
     </nav>
@@ -64,6 +65,62 @@
         <div class="card-body no-pad">
           <div class="map-wrap" data-module="live-map" id="live-map-slot"
                data-props='{"serverId":"__SERVER_ID__"}'></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="view-panel" data-view="settings">
+      <div class="card full-width">
+        <div class="card-head">
+          <div class="card-title">Discord Integration</div>
+          <div class="card-tools">
+            <span class="badge offline" id="discord-bot-status">Offline</span>
+          </div>
+        </div>
+        <div class="card-body" id="discord-settings">
+          <div class="discord-settings-grid">
+            <section class="discord-status" aria-live="polite">
+              <h3 class="section-title">Live status</h3>
+              <div class="discord-status-summary">
+                <article class="discord-stat">
+                  <span class="label">Current players</span>
+                  <strong class="value" id="discord-current-players">0</strong>
+                </article>
+                <article class="discord-stat">
+                  <span class="label">Max players</span>
+                  <strong class="value" id="discord-max-players">—</strong>
+                </article>
+                <article class="discord-stat">
+                  <span class="label">Joining</span>
+                  <strong class="value" id="discord-joining">0</strong>
+                </article>
+              </div>
+              <p class="discord-last-check" id="discord-last-check">Last check: —</p>
+            </section>
+            <section class="discord-form-wrap">
+              <h3 class="section-title">Configure bot</h3>
+              <form id="discord-form" class="discord-form">
+                <label class="field">
+                  <span class="field-label">Discord bot token</span>
+                  <input type="password" id="discord-bot-token" name="botToken" autocomplete="off" placeholder="Paste bot token" />
+                  <small class="muted">Leave blank to keep the existing token.</small>
+                </label>
+                <label class="field">
+                  <span class="field-label">Discord server (guild) ID</span>
+                  <input type="text" id="discord-guild-id" name="guildId" inputmode="numeric" autocomplete="off" placeholder="e.g. 123456789012345678" />
+                </label>
+                <label class="field">
+                  <span class="field-label">Discord channel ID</span>
+                  <input type="text" id="discord-channel-id" name="channelId" inputmode="numeric" autocomplete="off" placeholder="e.g. 123456789012345678" />
+                </label>
+                <div class="form-actions">
+                  <button type="submit" class="btn">Save integration</button>
+                  <button type="button" class="btn ghost" id="discord-remove">Remove</button>
+                </div>
+                <p class="notice hidden discord-notice" id="discord-notice"></p>
+              </form>
+            </section>
+          </div>
         </div>
       </div>
     </section>
@@ -122,5 +179,6 @@
       activate('players');
     });
   </script>
+  <script defer src="/assets/js/server-settings.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add database storage helpers and REST endpoints to manage per-server Discord integrations
- surface integration state and live status details via the server API
- add a settings tab on the server page with UI to configure the Discord bot and view player metrics

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5491d376c8331aa45c7eaf9b395db