### PR TITLE
Polish player directory modal presentation

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -57,6 +57,7 @@ function createApi(pool, dialect) {
         server_id INT NOT NULL,
         steamid VARCHAR(32) NOT NULL,
         display_name VARCHAR(190) NULL,
+        forced_display_name VARCHAR(190) NULL,
         first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_ip VARCHAR(128) NULL,
@@ -76,6 +77,7 @@ function createApi(pool, dialect) {
       await ensureColumn('ALTER TABLE players ADD COLUMN playtime_updated_at TIMESTAMP NULL');
       await ensureColumn('ALTER TABLE server_players ADD COLUMN last_ip VARCHAR(128) NULL');
       await ensureColumn('ALTER TABLE server_players ADD COLUMN last_port INT NULL');
+      await ensureColumn('ALTER TABLE server_players ADD COLUMN forced_display_name VARCHAR(190) NULL');
       await exec(`CREATE TABLE IF NOT EXISTS player_events(
         id INT AUTO_INCREMENT PRIMARY KEY,
         steamid VARCHAR(32) NOT NULL,
@@ -164,14 +166,14 @@ function createApi(pool, dialect) {
       const portNum = Number(port);
       const portValue = Number.isFinite(portNum) ? Math.max(0, Math.trunc(portNum)) : null;
       await exec(`
-        INSERT INTO server_players(server_id, steamid, display_name, first_seen, last_seen, last_ip, last_port)
-        VALUES(?,?,?,?,?,?,?)
+        INSERT INTO server_players(server_id, steamid, display_name, forced_display_name, first_seen, last_seen, last_ip, last_port)
+        VALUES(?,?,?,?,?,?,?,?)
         ON DUPLICATE KEY UPDATE
           display_name=COALESCE(VALUES(display_name), server_players.display_name),
           last_seen=VALUES(last_seen),
           last_ip=COALESCE(VALUES(last_ip), server_players.last_ip),
           last_port=COALESCE(VALUES(last_port), server_players.last_port)
-      `,[serverIdNum,sid,display_name,seen,seen,ipValue,portValue]);
+      `,[serverIdNum,sid,display_name,null,seen,seen,ipValue,portValue]);
     },
     async recordServerPlayerCount({ server_id, player_count, max_players=null, queued=null, sleepers=null, recorded_at=null }){
       const serverIdNum = Number(server_id);
@@ -203,7 +205,7 @@ function createApi(pool, dialect) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
       return await exec(`
-        SELECT sp.server_id, sp.steamid, sp.display_name, sp.first_seen, sp.last_seen,
+        SELECT sp.server_id, sp.steamid, sp.display_name, sp.forced_display_name, sp.first_seen, sp.last_seen,
                sp.last_ip, sp.last_port,
                p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
                p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
@@ -213,6 +215,21 @@ function createApi(pool, dialect) {
         ORDER BY sp.last_seen DESC
         LIMIT ? OFFSET ?
       `,[serverIdNum,limit,offset]);
+    },
+    async setServerPlayerDisplayName({ server_id, steamid, display_name = null }){
+      const serverIdNum = Number(server_id);
+      if (!Number.isFinite(serverIdNum)) return 0;
+      const sid = String(steamid || '').trim();
+      if (!sid) return 0;
+      const value = typeof display_name === 'string' && display_name.trim()
+        ? display_name.trim().slice(0, 190)
+        : null;
+      const result = await exec(`
+        UPDATE server_players
+        SET forced_display_name=?
+        WHERE server_id=? AND steamid=?
+      `,[value,serverIdNum,sid]);
+      return result.affectedRows || 0;
     },
     async addPlayerEvent(ev){ await exec('INSERT INTO player_events(steamid,server_id,event,note) VALUES(?,?,?,?)',[ev.steamid, ev.server_id||null, ev.event, ev.note||null]); },
     async listPlayerEvents(steamid,{limit=100,offset=0}={}){ return await exec('SELECT * FROM player_events WHERE steamid=? ORDER BY id DESC LIMIT ? OFFSET ?',[steamid,limit,offset]); },

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -51,6 +51,7 @@ function createApi(dbh, dialect) {
         server_id INTEGER NOT NULL,
         steamid TEXT NOT NULL,
         display_name TEXT,
+        forced_display_name TEXT,
         first_seen TEXT DEFAULT (datetime('now')),
         last_seen TEXT DEFAULT (datetime('now')),
         last_ip TEXT,
@@ -121,6 +122,7 @@ function createApi(dbh, dialect) {
       };
       await ensureServerPlayerColumn('last_ip', 'last_ip TEXT');
       await ensureServerPlayerColumn('last_port', 'last_port INTEGER');
+      await ensureServerPlayerColumn('forced_display_name', 'forced_display_name TEXT');
     },
     async countUsers(){ const r = await dbh.get('SELECT COUNT(*) c FROM users'); return r.c; },
     async createUser(u){
@@ -191,14 +193,14 @@ function createApi(dbh, dialect) {
       const portNum = Number(port);
       const portValue = Number.isFinite(portNum) ? portNum : null;
       await dbh.run(`
-        INSERT INTO server_players(server_id, steamid, display_name, first_seen, last_seen, last_ip, last_port)
-        VALUES(?,?,?,?,?,?,?)
+        INSERT INTO server_players(server_id, steamid, display_name, forced_display_name, first_seen, last_seen, last_ip, last_port)
+        VALUES(?,?,?,?,?,?,?,?)
         ON CONFLICT(server_id, steamid) DO UPDATE SET
           display_name=COALESCE(excluded.display_name, server_players.display_name),
           last_seen=excluded.last_seen,
           last_ip=COALESCE(excluded.last_ip, server_players.last_ip),
           last_port=COALESCE(excluded.last_port, server_players.last_port)
-      `,[serverIdNum,sid,display_name,seen,seen,ipValue,portValue]);
+      `,[serverIdNum,sid,display_name,null,seen,seen,ipValue,portValue]);
     },
     async recordServerPlayerCount({ server_id, player_count, max_players = null, queued = null, sleepers = null, recorded_at = null }){
       const serverIdNum = Number(server_id);
@@ -229,16 +231,27 @@ function createApi(dbh, dialect) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
       return await dbh.all(`
-        SELECT sp.server_id, sp.steamid, sp.display_name, sp.first_seen, sp.last_seen,
-               sp.last_ip, sp.last_port,
-               p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
-               p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
+        SELECT sp.server_id, sp.steamid, sp.display_name, sp.forced_display_name, sp.first_seen, sp.last_seen,
+                sp.last_ip, sp.last_port,
+                p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
+                p.last_ban_days, p.visibility, p.rust_playtime_minutes, p.playtime_updated_at, p.updated_at
         FROM server_players sp
         LEFT JOIN players p ON p.steamid = sp.steamid
         WHERE sp.server_id=?
         ORDER BY sp.last_seen DESC
         LIMIT ? OFFSET ?
       `,[serverIdNum,limit,offset]);
+    },
+    async setServerPlayerDisplayName({ server_id, steamid, display_name = null }){
+      const serverIdNum = Number(server_id);
+      if (!Number.isFinite(serverIdNum)) return 0;
+      const sid = String(steamid || '').trim();
+      if (!sid) return 0;
+      const value = typeof display_name === 'string' && display_name.trim()
+        ? display_name.trim().slice(0, 190)
+        : null;
+      const result = await dbh.run('UPDATE server_players SET forced_display_name=? WHERE server_id=? AND steamid=?',[value,serverIdNum,sid]);
+      return result.changes || 0;
     },
     async addPlayerEvent(ev){ await dbh.run('INSERT INTO player_events(steamid,server_id,event,note) VALUES(?,?,?,?)',[ev.steamid, ev.server_id||null, ev.event, ev.note||null]); },
     async listPlayerEvents(steamid,{limit=100,offset=0}={}){ return await dbh.all('SELECT * FROM player_events WHERE steamid=? ORDER BY id DESC LIMIT ? OFFSET ?',[steamid,limit,offset]); },

--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -110,16 +110,22 @@ main.grid{
 .players-directory{padding:0}
 .players-directory .module-message{padding:24px; text-align:center}
 .player-directory{
-  list-style:none; margin:0; padding:0; display:flex; flex-direction:column;
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
 }
+.player-directory .player-name-row{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
 .player-directory li{
   display:flex; justify-content:space-between; gap:18px; align-items:flex-start;
   padding:16px 18px; border-bottom:1px solid var(--border);
   background:rgba(12,15,23,.6);
-  cursor:pointer; transition:background .15s ease, border-color .15s ease;
+  cursor:pointer; transition:background .18s ease, border-color .18s ease, transform .18s ease, box-shadow .18s ease;
 }
 .player-directory li:nth-child(even){background:rgba(255,255,255,.02)}
-.player-directory li:hover{background:rgba(225,29,72,.12); border-color:rgba(225,29,72,.35)}
+.player-directory li:hover{background:rgba(225,29,72,.14); border-color:rgba(225,29,72,.38); transform:translateX(2px)}
+.player-directory li.active{background:rgba(225,29,72,.18); border-color:rgba(225,29,72,.45); box-shadow:0 16px 32px rgba(225,29,72,.22)}
 .player-directory li:focus-visible{outline:2px solid rgba(225,29,72,.6); outline-offset:2px}
 .player-directory strong{font-weight:600}
 .player-directory .muted{color:var(--muted)}
@@ -282,10 +288,12 @@ main.grid{
   position:fixed; inset:0; z-index:90;
   background:rgba(6,9,15,.72);
   backdrop-filter:blur(12px);
-  display:flex; align-items:flex-start; justify-content:center;
-  padding:60px 16px 30px; overflow:auto;
+  display:flex; align-items:center; justify-content:center;
+  padding:40px 16px; overflow:auto;
+  opacity:0; pointer-events:none; transition:opacity .18s ease;
 }
 .player-modal-backdrop.hidden{display:none}
+.player-modal-backdrop[aria-hidden="false"]{opacity:1; pointer-events:auto}
 .player-modal{
   width:min(560px, 100%);
   background:linear-gradient(180deg, #121722 0%, #0b0f19 100%);
@@ -294,6 +302,7 @@ main.grid{
   box-shadow:0 20px 48px rgba(0,0,0,.55);
   display:flex; flex-direction:column; overflow:hidden;
   animation:playerModalIn .18s ease;
+  max-height:min(720px, calc(100vh - 80px));
 }
 .player-modal-header{
   padding:20px 22px; display:flex; align-items:center; justify-content:space-between;

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1061,11 +1061,35 @@ button.menu-tab.active {
   padding: 16px 18px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .player-directory li:nth-child(even) { background: rgba(255, 255, 255, 0.05); }
 
+.player-directory li:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(2px);
+}
+
+.player-directory li.active {
+  background: rgba(225, 29, 72, 0.14);
+  box-shadow: 0 10px 24px rgba(225, 29, 72, 0.18);
+  border-color: rgba(225, 29, 72, 0.4);
+}
+
 .player-directory strong { font-weight: 600; }
+
+.player-directory .player-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.player-directory .muted { color: var(--muted); }
+
+.player-directory .small { font-size: 0.78rem; }
 
 .player-directory .server-actions {
   display: flex;
@@ -1416,6 +1440,196 @@ pre {
   background: rgba(251, 191, 36, 0.14);
   border-color: rgba(251, 191, 36, 0.38);
   color: #fef08a;
+}
+
+body.modal-open { overflow: hidden; }
+
+.player-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(10, 1, 5, 0.78);
+  backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+  overflow: auto;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+}
+
+.player-modal-backdrop.hidden { display: none !important; }
+
+.player-modal-backdrop[aria-hidden="false"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.player-modal {
+  width: min(560px, 100%);
+  background: linear-gradient(180deg, rgba(34, 7, 16, 0.96) 0%, rgba(14, 3, 7, 0.94) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 28px 64px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: playerModalIn 0.18s ease;
+  max-height: min(720px, calc(100vh - 80px));
+}
+
+.player-modal-header {
+  padding: 22px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.player-modal-title { display: flex; align-items: center; gap: 16px; }
+
+.player-modal-avatar {
+  width: 68px;
+  height: 68px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.player-modal-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+.player-modal-heading { display: flex; flex-direction: column; gap: 6px; }
+
+.player-modal-name { font-weight: 700; font-size: 1.15rem; }
+
+.player-modal-persona { font-size: 0.88rem; color: var(--muted); }
+
+.player-modal-meta { font-size: 0.8rem; color: var(--muted); }
+
+.player-modal-badges { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; }
+
+.player-modal-close {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.player-modal-close:hover { filter: brightness(1.1); }
+
+.player-modal-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.player-modal-loading {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--muted);
+}
+
+.player-modal-details {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 10px 20px;
+  margin: 0;
+}
+
+.player-modal-details dt {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.player-modal-details dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.player-modal-events h4 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.player-event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.player-event-row {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.player-event-empty {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 14px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.player-event-row strong { font-weight: 600; }
+
+.event-meta { font-size: 0.78rem; color: var(--muted); }
+
+.player-modal-footer {
+  padding: 20px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.player-modal-status {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.player-modal-status.hidden { display: none !important; }
+
+.player-modal-status[data-variant="success"] { color: #bbf7d0; }
+
+.player-modal-status[data-variant="error"] { color: #fecaca; }
+
+.player-modal-status[data-variant="warn"] { color: #fde68a; }
+
+.player-modal-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+
+@keyframes playerModalIn {
+  from { transform: translateY(18px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- keep the selected player row highlighted while its floating details modal is open
- add hover and active treatments to player directory rows so they feel clickable in both themes
- fade in the modal backdrop and cap the dialog height so the overlay reads like a centered floating panel

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5465e2b9c8331934a54e3718d87d0