### PR TITLE
Remove stray script tags from server settings bundle

### DIFF
--- a/frontend/assets/js/server-settings.js
+++ b/frontend/assets/js/server-settings.js
@@ -1,4 +1,3 @@
-<script>
 (() => {
   const settingsRoot = document.getElementById('discord-settings');
   if (!settingsRoot) return;
@@ -380,4 +379,3 @@
     setNotice(describeError('missing_server'));
   }
 })();
-</script>


### PR DESCRIPTION
## Summary
- remove HTML <script> wrapper around the discord server settings JavaScript bundle so browsers can execute it as plain JS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55431c5cc83319c26cd7af303b5f9