### PR TITLE
Add profile menu to live players card

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -478,6 +478,102 @@ label { display: flex; flex-direction: column; gap: 6px; font-size: 0.92rem; col
   background: rgba(248, 113, 113, 0.24);
 }
 
+.player-profile-menu {
+  position: absolute;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--panel-strong);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  color: var(--muted-strong);
+  z-index: 35;
+}
+
+.player-profile-menu-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.player-profile-menu-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+}
+
+.player-profile-menu-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.player-profile-menu-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-profile-menu-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.player-profile-menu-sub {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.player-profile-menu-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.player-profile-menu-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--muted-strong);
+}
+
+.player-profile-menu-meta-row .label {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.player-profile-menu-meta-row .value {
+  color: var(--text);
+  font-weight: 600;
+  text-align: right;
+  word-break: break-all;
+}
+
+.player-profile-menu-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.menu-link {
+  text-decoration: none;
+  color: inherit;
+}
+
 .menu-description {
   display: block;
   font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- open a contextual profile menu from the Connected Players card to review key details
- include a direct Steam profile button in the new menu for quicker access
- add styling for the player profile popover so it matches the dashboard aesthetic

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d5695af1b88331b3cf62495967f506