### PR TITLE
Avoid shutting down Discord bots during cooldowns

### DIFF
--- a/backend/src/discord-bot-service.js
+++ b/backend/src/discord-bot-service.js
@@ -125,7 +125,7 @@ async function ensureBot(integration) {
 
   const now = Date.now();
   if (state.cooldownUntil > now) {
-    return null;
+    return state;
   }
 
   if (!state.ready) {
@@ -168,7 +168,7 @@ async function ensureBot(integration) {
     try {
       await state.connectPromise;
     } catch (err) {
-      return null;
+      return state;
     }
   }
 


### PR DESCRIPTION
## Summary
- keep discord bot states active while they are in a reconnect cooldown
- prevent the service from logging that integrations are missing after a transient login failure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5705585f48331be547f4f94a3afa6