### PR TITLE
Fix profile button fallback and ban messaging

### DIFF
--- a/frontend/assets/js/panel-shell.js
+++ b/frontend/assets/js/panel-shell.js
@@ -14,16 +14,31 @@
     if (!player) return;
     const profile = player.steamProfile || {};
     const displayName = profile.persona || player.displayName || player.DisplayName || player.steamId || player.SteamID || 'Player';
+    const steamIdValue = player.steamId || player.SteamID || '';
+    const steamProfileUrl = profile.profileUrl || (steamIdValue ? `https://steamcommunity.com/profiles/${encodeURIComponent(steamIdValue)}` : '');
+    const serverArmourUrl = steamIdValue ? `https://serverarmour.com/profile/${encodeURIComponent(steamIdValue)}` : '';
     const playtimeText = formatPlaytime(profile.rustPlaytimeMinutes, profile.visibility);
     const vacText = profile.vacBanned ? 'Yes' : 'No';
     const gameBanCount = Number(profile.gameBans) > 0 ? Number(profile.gameBans) : 0;
-    const lastBan = Number.isFinite(Number(profile.daysSinceLastBan)) ? `${profile.daysSinceLastBan} day${profile.daysSinceLastBan === 1 ? '' : 's'} ago` : '—';
+    const rawDaysSinceBan = Number(profile.daysSinceLastBan);
+    const hasBanAge = Number.isFinite(rawDaysSinceBan) && rawDaysSinceBan >= 0;
+    const lastBan = hasBanAge
+      ? rawDaysSinceBan === 0
+        ? 'Today'
+        : `${rawDaysSinceBan} day${rawDaysSinceBan === 1 ? '' : 's'} ago`
+      : '—';
     const ipText = player.ip ? `${player.ip}${player.port ? ':' + player.port : ''}` : 'Hidden';
     const position = player.position || player.Position || {};
     const positionText = `${Math.round(position.x ?? 0)}, ${Math.round(position.z ?? 0)}`;
-    const nameValue = profile.profileUrl
-      ? `<a href="${escapeAttr(profile.profileUrl)}" target="_blank" rel="noreferrer">${escapeHtml(displayName)}</a>`
-      : escapeHtml(displayName);
+    const nameValue = escapeHtml(displayName);
+    const actions = [];
+    if (steamProfileUrl) {
+      actions.push('<button type="button" class="ghost small" data-action="steam-profile">Steam profile</button>');
+    }
+    if (serverArmourUrl) {
+      actions.push('<button type="button" class="ghost small" data-action="server-armour">Server Armour</button>');
+    }
+    const actionsBlock = actions.length ? `<div class="profile-actions">${actions.join('')}</div>` : '';
     infoTitle.textContent = 'Player Info';
     infoContent.innerHTML = `
       <div class="kv"><div class="k">Name:</div><div>${nameValue}</div></div>
@@ -37,7 +52,20 @@
       <div class="kv"><div class="k">Country:</div><div>${escapeHtml(profile.country || '—')}</div></div>
       <div class="kv"><div class="k">Address:</div><div>${escapeHtml(ipText)}</div></div>
       <div class="kv"><div class="k">Position:</div><div>(${positionText})</div></div>
+      ${actionsBlock}
     `;
+    const steamBtn = infoContent.querySelector('[data-action="steam-profile"]');
+    if (steamBtn && steamProfileUrl) {
+      steamBtn.addEventListener('click', () => {
+        window.open(steamProfileUrl, '_blank', 'noopener,noreferrer');
+      });
+    }
+    const armourBtn = infoContent.querySelector('[data-action="server-armour"]');
+    if (armourBtn && serverArmourUrl) {
+      armourBtn.addEventListener('click', () => {
+        window.open(serverArmourUrl, '_blank', 'noopener,noreferrer');
+      });
+    }
   });
 
   // Show server info again

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -125,6 +125,21 @@ button.ghost.danger:hover {
 
 button.small { padding: 7px 14px; font-size: 0.9rem; border-radius: 999px; }
 
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.profile-actions button {
+  flex: 1 1 160px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 button.icon {
   width: 40px;
   height: 40px;


### PR DESCRIPTION
## Summary
- replace the player info name link with plain text and add action buttons for profile utilities
- provide buttons to open the Steam profile (with a SteamID fallback) and the Server Armour lookup for the selected player
- style the new action buttons within the floating profile panel
- ensure the game ban summary only shows recent ban timing when it applies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d578e5889c8331b3e88182eaee137c