### PR TITLE
Add modal profile buttons for Steam and Server Armour

### DIFF
--- a/frontend/assets/js/panel-shell.js
+++ b/frontend/assets/js/panel-shell.js
@@ -17,7 +17,13 @@
     const playtimeText = formatPlaytime(profile.rustPlaytimeMinutes, profile.visibility);
     const vacText = profile.vacBanned ? 'Yes' : 'No';
     const gameBanCount = Number(profile.gameBans) > 0 ? Number(profile.gameBans) : 0;
-    const lastBan = Number.isFinite(Number(profile.daysSinceLastBan)) ? `${profile.daysSinceLastBan} day${profile.daysSinceLastBan === 1 ? '' : 's'} ago` : '—';
+    const rawDaysSinceBan = Number(profile.daysSinceLastBan);
+    const hasBanAge = Number.isFinite(rawDaysSinceBan) && rawDaysSinceBan >= 0;
+    const lastBan = hasBanAge
+      ? rawDaysSinceBan === 0
+        ? 'Today'
+        : `${rawDaysSinceBan} day${rawDaysSinceBan === 1 ? '' : 's'} ago`
+      : '—';
     const ipText = player.ip ? `${player.ip}${player.port ? ':' + player.port : ''}` : 'Hidden';
     const position = player.position || player.Position || {};
     const positionText = `${Math.round(position.x ?? 0)}, ${Math.round(position.z ?? 0)}`;

--- a/frontend/assets/modules/live-players.js
+++ b/frontend/assets/modules/live-players.js
@@ -19,6 +19,14 @@
     return `${hours.toFixed(1)} h`;
   }
 
+  function formatLastBan(days) {
+    const value = Number(days);
+    if (!Number.isFinite(value) || value < 0) return '';
+    if (value === 0) return 'Today';
+    if (value === 1) return '1 day ago';
+    return `${value} days ago`;
+  }
+
   function mapPlayerForDirectory(player) {
     if (!player) return null;
     const profile = player.steamProfile || {};
@@ -359,10 +367,11 @@
             gameBan.textContent = `${profile.gameBans} game ban${profile.gameBans > 1 ? 's' : ''}`;
             badges.appendChild(gameBan);
           }
-          if (Number.isFinite(profile.daysSinceLastBan)) {
+          const lastBanLabel = formatLastBan(profile.daysSinceLastBan);
+          if (lastBanLabel) {
             const last = document.createElement('span');
             last.className = 'badge warn';
-            last.textContent = `${profile.daysSinceLastBan}d since last ban`;
+            last.textContent = `Last ban: ${lastBanLabel}`;
             badges.appendChild(last);
           }
           if (badges.childElementCount > 0) details.appendChild(badges);

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -598,13 +598,31 @@
 
       function updateActions(combined) {
         const profileUrl = combined.profileurl || combined.profile_url || '';
-        if (modal.elements.profileLink) {
-          if (profileUrl) {
-            modal.elements.profileLink.classList.remove('hidden');
-            modal.elements.profileLink.href = profileUrl;
+        const steamid = typeof combined.steamid === 'string'
+          ? combined.steamid.trim()
+          : String(combined.steamid || '').trim();
+        const steamProfileUrl = profileUrl || (steamid ? `https://steamcommunity.com/profiles/${encodeURIComponent(steamid)}` : '');
+        const serverArmourUrl = steamid ? `https://serverarmour.com/profile/${encodeURIComponent(steamid)}` : '';
+        if (modal.elements.steamProfileBtn) {
+          if (steamProfileUrl) {
+            modal.elements.steamProfileBtn.classList.remove('hidden');
+            modal.elements.steamProfileBtn.dataset.url = steamProfileUrl;
+            modal.elements.steamProfileBtn.disabled = false;
           } else {
-            modal.elements.profileLink.classList.add('hidden');
-            modal.elements.profileLink.removeAttribute('href');
+            modal.elements.steamProfileBtn.classList.add('hidden');
+            modal.elements.steamProfileBtn.dataset.url = '';
+            modal.elements.steamProfileBtn.disabled = true;
+          }
+        }
+        if (modal.elements.serverArmourBtn) {
+          if (serverArmourUrl) {
+            modal.elements.serverArmourBtn.classList.remove('hidden');
+            modal.elements.serverArmourBtn.dataset.url = serverArmourUrl;
+            modal.elements.serverArmourBtn.disabled = false;
+          } else {
+            modal.elements.serverArmourBtn.classList.add('hidden');
+            modal.elements.serverArmourBtn.dataset.url = '';
+            modal.elements.serverArmourBtn.disabled = true;
           }
         }
         if (modal.elements.refreshBtn) {
@@ -831,12 +849,16 @@
         refreshBtn.className = 'btn small';
         refreshBtn.textContent = 'Force Steam Refresh';
         actions.appendChild(refreshBtn);
-        const profileLink = document.createElement('a');
-        profileLink.className = 'btn ghost small hidden';
-        profileLink.textContent = 'Open Steam Profile';
-        profileLink.target = '_blank';
-        profileLink.rel = 'noreferrer';
-        actions.appendChild(profileLink);
+        const steamProfileBtn = document.createElement('button');
+        steamProfileBtn.type = 'button';
+        steamProfileBtn.className = 'btn ghost small hidden';
+        steamProfileBtn.textContent = 'Open Steam Profile';
+        actions.appendChild(steamProfileBtn);
+        const serverArmourBtn = document.createElement('button');
+        serverArmourBtn.type = 'button';
+        serverArmourBtn.className = 'btn ghost small hidden';
+        serverArmourBtn.textContent = 'Server Armour';
+        actions.appendChild(serverArmourBtn);
         footer.appendChild(actions);
 
         document.body.appendChild(overlay);
@@ -849,11 +871,23 @@
           if (ev.key === 'Escape') hide();
         };
 
+        const openSteamProfile = () => {
+          const url = steamProfileBtn.dataset.url;
+          if (url) window.open(url, '_blank', 'noopener,noreferrer');
+        };
+
+        const openServerArmour = () => {
+          const url = serverArmourBtn.dataset.url;
+          if (url) window.open(url, '_blank', 'noopener,noreferrer');
+        };
+
         overlay.addEventListener('click', onBackdrop);
         dialog.addEventListener('click', (ev) => ev.stopPropagation());
         closeBtn.addEventListener('click', hide);
         refreshBtn.addEventListener('click', forceSteamRefresh);
         forceNameBtn.addEventListener('click', forceDisplayName);
+        steamProfileBtn.addEventListener('click', openSteamProfile);
+        serverArmourBtn.addEventListener('click', openServerArmour);
 
         return {
           show() {
@@ -881,7 +915,8 @@
             status,
             refreshBtn,
             forceNameBtn,
-            profileLink,
+            steamProfileBtn,
+            serverArmourBtn,
             loading
           },
           overlay,
@@ -891,6 +926,8 @@
             closeBtn.removeEventListener('click', hide);
             refreshBtn.removeEventListener('click', forceSteamRefresh);
             forceNameBtn.removeEventListener('click', forceDisplayName);
+            steamProfileBtn.removeEventListener('click', openSteamProfile);
+            serverArmourBtn.removeEventListener('click', openServerArmour);
             overlay.remove();
           }
         };


### PR DESCRIPTION
## Summary
- add dedicated Steam and Server Armour buttons to the player profile modal with a SteamID fallback when the profile URL is missing
- format the live players list to show clearer last-ban timing and remove unused floating action styles
- keep the floating info panel name link while retaining the safer last-ban wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d578e5889c8331b3e88182eaee137c