### PR TITLE
Fix live map world caching and map auth

### DIFF
--- a/backend/src/auth.js
+++ b/backend/src/auth.js
@@ -9,14 +9,34 @@ export function signToken(user, secret) {
   return jwt.sign(payload, secret, { expiresIn: '7d' });
 }
 
-export function authMiddleware(secret) {
+function extractQueryToken(req) {
+  const candidates = [
+    req.query?.token,
+    req.query?.auth,
+    req.query?.authToken,
+    req.query?.access_token
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+export function authMiddleware(secret, options = {}) {
+  const { allowQueryToken = false } = options;
   return (req, res, next) => {
     const header = req.headers.authorization || '';
-    const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+    let token = header.startsWith('Bearer ') ? header.slice(7) : null;
+    if (!token && allowQueryToken) {
+      token = extractQueryToken(req);
+    }
     if (!token) return res.status(401).json({ error: 'missing_token' });
     try {
       const payload = jwt.verify(token, secret);
       req.user = payload;
+      req.authToken = token;
       next();
     } catch (e) {
       return res.status(401).json({ error: 'invalid_token' });


### PR DESCRIPTION
## Summary
- allow JWT authentication via query tokens so map images can be requested from `<img>` elements without losing auth
- pull fresh world size/seed details on every live-map request and reuse cached RustMaps imagery keyed by `seed_size`
- embed signed map-image URLs in live-map responses to keep cached imagery accessible without manual input

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d5851188f8833190857da41e5f7a6b