### PR TITLE
Route frontend API traffic through /api proxy

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -383,7 +383,7 @@
         configSubmit.disabled = true;
         showConfigStatus('Requesting map from RustMaps…');
         try {
-          const response = await ctx.api(`/api/servers/${state.serverId}/live-map/world`, { size, seed }, 'POST');
+          const response = await ctx.api(`/servers/${state.serverId}/live-map/world`, { size, seed }, 'POST');
           if (response?.info) {
             state.serverInfo = { ...(state.serverInfo || {}), ...response.info };
           } else {
@@ -464,7 +464,7 @@
           const dataUrl = await readFileAsDataURL(file);
           const activeMeta = getActiveMapMeta();
           const payload = { image: dataUrl, mapKey: activeMeta?.mapKey || null };
-          const response = await ctx.api(`/api/servers/${state.serverId}/map-image`, payload, 'POST');
+          const response = await ctx.api(`/servers/${state.serverId}/map-image`, payload, 'POST');
           if (response?.map) {
             state.mapMeta = response.map;
             state.mapMetaServerId = state.serverId;
@@ -1084,7 +1084,7 @@
         hideUploadNotice();
         if (reason !== 'poll' && reason !== 'map-pending') setMessage('Loading live map data…');
         try {
-          const data = await ctx.api(`/api/servers/${state.serverId}/live-map`);
+          const data = await ctx.api(`/servers/${state.serverId}/live-map`);
           state.players = Array.isArray(data?.players) ? data.players : [];
           const previousMeta = getActiveMapMeta();
           const previousKey = previousMeta?.mapKey ?? null;

--- a/frontend/assets/modules/players-graph.js
+++ b/frontend/assets/modules/players-graph.js
@@ -385,7 +385,7 @@
         setMessage('Loading player history…');
         try {
           const params = new URLSearchParams({ range: state.rangeParam, interval: state.intervalParam });
-          const result = await (typeof ctx.api === 'function' ? ctx.api(`/api/servers/${state.serverId}/player-counts?${params}`) : defaultApi(`/api/servers/${state.serverId}/player-counts?${params}`));
+          const result = await (typeof ctx.api === 'function' ? ctx.api(`/servers/${state.serverId}/player-counts?${params}`) : defaultApi(`/servers/${state.serverId}/player-counts?${params}`));
           state.buckets = Array.isArray(result?.buckets) ? result.buckets : [];
           state.summary = result?.summary || null;
           state.intervalSeconds = safeNumber(result?.intervalSeconds);

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -344,7 +344,7 @@
         setMessage('Loading players…');
         updateCount(null, null);
         try {
-          const players = await ctx.api(`/api/servers/${serverId}/players?limit=200`);
+          const players = await ctx.api(`/servers/${serverId}/players?limit=200`);
           render(players);
         } catch (err) {
           if (ctx.errorCode?.(err) === 'unauthorized') {
@@ -672,7 +672,7 @@
         if (basePlayer) renderModal(basePlayer, null);
         if (showLoading) setModalLoading(true);
         try {
-          const details = await ctx.api(`/api/players/${steamid}`);
+          const details = await ctx.api(`/players/${steamid}`);
           if (!modalState.open || modalState.steamid !== target) return;
           renderModal(null, details);
           setModalStatus('');
@@ -694,7 +694,7 @@
         renderModal(null, null);
         setModalStatus('Requesting fresh Steam profile…');
         try {
-          await ctx.api('/api/steam/sync', { steamids: [modalState.steamid] }, 'POST');
+          await ctx.api('/steam/sync', { steamids: [modalState.steamid] }, 'POST');
           setModalStatus('Steam profile refresh requested. Updating record…', 'success');
           await refresh('steam-refresh');
           const updated = state.players.find((p) => String(p.steamid || '') === modalState.steamid);
@@ -738,7 +738,7 @@
         renderModal(null, null);
         setModalStatus(clearing ? 'Clearing forced display name…' : 'Saving display name…');
         try {
-          await ctx.api(`/api/servers/${serverId}/players/${modalState.steamid}`, { display_name: clearing ? null : next }, 'PATCH');
+          await ctx.api(`/servers/${serverId}/players/${modalState.steamid}`, { display_name: clearing ? null : next }, 'PATCH');
           setModalStatus(clearing ? 'Forced name cleared.' : 'Display name saved.', 'success');
           await refresh('display-name-change', serverId);
           const updated = state.players.find((player) => String(player.steamid || '') === modalState.steamid);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="panel-api-base" content="http://localhost:8787" />
+  <meta name="panel-api-base" content="/api" />
   <title>Rust Admin Online — Open Source</title>
   <link rel="stylesheet" href="assets/styles.css" />
 </head>


### PR DESCRIPTION
## Summary
- normalize the dashboard API base so it defaults to the /api prefix and stop hard-coding port 8787
- update core UI modules, websocket initialization, and server settings helpers to issue requests relative to the /api proxy
- set the frontend metadata default to /api so nginx can handle routing to the backend service

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d64e3b5a608331a2d8e589942b710d