### PR TITLE
Finalize custom role management integration

### DIFF
--- a/backend/src/auth.js
+++ b/backend/src/auth.js
@@ -9,14 +9,25 @@ export function signToken(user, secret) {
   return jwt.sign(payload, secret, { expiresIn: '7d' });
 }
 
-export function authMiddleware(secret) {
-  return (req, res, next) => {
+export function authMiddleware(secret, options = {}) {
+  const { loadUserContext } = options;
+  return async (req, res, next) => {
     const header = req.headers.authorization || '';
     const token = header.startsWith('Bearer ') ? header.slice(7) : null;
     if (!token) return res.status(401).json({ error: 'missing_token' });
     try {
       const payload = jwt.verify(token, secret);
       req.user = payload;
+      if (typeof loadUserContext === 'function') {
+        try {
+          const context = await loadUserContext(payload.uid);
+          if (!context) return res.status(401).json({ error: 'invalid_user' });
+          req.authUser = context;
+        } catch (err) {
+          console.error('auth context load failed', err);
+          return res.status(500).json({ error: 'auth_context_error' });
+        }
+      }
       next();
     } catch (e) {
       return res.status(401).json({ error: 'invalid_token' });
@@ -25,6 +36,7 @@ export function authMiddleware(secret) {
 }
 
 export function requireAdmin(req, res, next) {
-  if (req.user?.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  const hasPermission = req.authUser?.permissions?.global?.manageUsers;
+  if (req.user?.role !== 'admin' && !hasPermission) return res.status(403).json({ error: 'forbidden' });
   next();
 }

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import sqlite from './sqlite.js';
 import mysql from './mysql.js';
+import { normaliseRolePermissions, serialiseRolePermissions } from '../permissions.js';
 
 const client = (process.env.DB_CLIENT || 'sqlite').toLowerCase();
 let db;
@@ -23,11 +24,53 @@ export { db };
 
 export async function initDb() {
   await db.init();
+  await ensureDefaultRoles();
   const bcrypt = await import('bcrypt');
   const count = await db.countUsers();
   if (count === 0) {
     const hash = bcrypt.hashSync('admin123', 10);
     await db.createUser({ username: 'admin', password_hash: hash, role: 'admin' });
     console.log('Created default admin: admin / admin123');
+  }
+}
+
+const DEFAULT_ROLES = [
+  {
+    key: 'admin',
+    name: 'Administrator',
+    description: 'Full access to every server and control panel feature.',
+    permissions: serialiseRolePermissions({
+      servers: { allowed: ['*'] },
+      global: { manageUsers: true, manageServers: true, manageRoles: true }
+    }, 'admin')
+  },
+  {
+    key: 'user',
+    name: 'Operator',
+    description: 'Access to all servers without team management privileges.',
+    permissions: serialiseRolePermissions({
+      servers: { allowed: ['*'] },
+      global: { manageUsers: false, manageServers: true, manageRoles: false }
+    }, 'user')
+  }
+];
+
+async function ensureDefaultRoles() {
+  if (typeof db.listRoles !== 'function') return;
+  for (const role of DEFAULT_ROLES) {
+    const existing = await db.getRole(role.key);
+    if (!existing) {
+      await db.createRole(role);
+      continue;
+    }
+    const desired = normaliseRolePermissions(role.permissions, role.key);
+    const current = normaliseRolePermissions(existing.permissions, role.key);
+    const updates = {};
+    if (existing.name !== role.name) updates.name = role.name;
+    if ((existing.description || '') !== (role.description || '')) updates.description = role.description;
+    if (JSON.stringify(current) !== JSON.stringify(desired)) updates.permissions = role.permissions;
+    if (Object.keys(updates).length) {
+      await db.updateRole(role.key, updates);
+    }
   }
 }

--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -15,6 +15,15 @@ function createApi(pool, dialect) {
   return {
     dialect,
     async init() {
+      await exec(`CREATE TABLE IF NOT EXISTS roles(
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        role_key VARCHAR(64) UNIQUE NOT NULL,
+        name VARCHAR(190) NOT NULL,
+        description TEXT NULL,
+        permissions JSON NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB;`);
       await exec(`CREATE TABLE IF NOT EXISTS users(
         id INT AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(190) UNIQUE NOT NULL,
@@ -133,9 +142,17 @@ function createApi(pool, dialect) {
       const r = await exec('INSERT INTO users(username,password_hash,role) VALUES(?,?,?)',[username,password_hash,role]);
       return r.insertId;
     },
-    async getUser(id){ const r = await exec('SELECT * FROM users WHERE id=?',[id]); return r[0]||null; },
-    async getUserByUsername(u){ const r = await exec('SELECT * FROM users WHERE username=?',[u]); return r[0]||null; },
-    async listUsers(){ return await exec('SELECT id,username,role,created_at FROM users ORDER BY id ASC'); },
+    async getUser(id){
+      const rows = await exec(`SELECT u.*, r.name AS role_name, r.permissions AS role_permissions FROM users u LEFT JOIN roles r ON r.role_key = u.role WHERE u.id=?`, [id]);
+      return rows[0] || null;
+    },
+    async getUserByUsername(u){
+      const rows = await exec(`SELECT u.*, r.name AS role_name, r.permissions AS role_permissions FROM users u LEFT JOIN roles r ON r.role_key = u.role WHERE u.username=?`, [u]);
+      return rows[0] || null;
+    },
+    async listUsers(){
+      return await exec(`SELECT u.id, u.username, u.role, u.created_at, r.name AS role_name FROM users u LEFT JOIN roles r ON r.role_key = u.role ORDER BY u.id ASC`);
+    },
     async countAdmins(){ const r = await exec("SELECT COUNT(*) c FROM users WHERE role='admin'"); const row = Array.isArray(r)?r[0]:r; return row.c ?? row['COUNT(*)']; },
     async updateUserPassword(id, hash){ await exec('UPDATE users SET password_hash=? WHERE id=?',[hash,id]); },
     async updateUserRole(id, role){ await exec('UPDATE users SET role=? WHERE id=?',[role,id]); },
@@ -343,6 +360,53 @@ function createApi(pool, dialect) {
       if (typeof result.affectedRows === 'number') return result.affectedRows;
       if (Array.isArray(result) && typeof result[0]?.affectedRows === 'number') return result[0].affectedRows;
       return 0;
+    },
+    async listRoles(){
+      const rows = await exec('SELECT role_key, name, description, permissions, created_at, updated_at FROM roles ORDER BY name ASC');
+      return rows.map((row) => ({
+        key: row.role_key,
+        name: row.name,
+        description: row.description,
+        permissions: typeof row.permissions === 'string' ? row.permissions : JSON.stringify(row.permissions ?? {}),
+        created_at: row.created_at,
+        updated_at: row.updated_at
+      }));
+    },
+    async getRole(key){
+      const rows = await exec('SELECT role_key, name, description, permissions, created_at, updated_at FROM roles WHERE role_key=?', [key]);
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        key: row.role_key,
+        name: row.name,
+        description: row.description,
+        permissions: typeof row.permissions === 'string' ? row.permissions : JSON.stringify(row.permissions ?? {}),
+        created_at: row.created_at,
+        updated_at: row.updated_at
+      };
+    },
+    async createRole(role){
+      await exec('INSERT INTO roles(role_key, name, description, permissions) VALUES(?,?,?,?)', [role.key, role.name, role.description ?? null, role.permissions ?? '{}']);
+    },
+    async updateRole(key, payload){
+      const existing = await this.getRole(key);
+      if (!existing) return 0;
+      const next = {
+        name: typeof payload.name === 'undefined' ? existing.name : payload.name,
+        description: typeof payload.description === 'undefined' ? existing.description : payload.description,
+        permissions: typeof payload.permissions === 'undefined' ? existing.permissions : payload.permissions
+      };
+      const res = await exec('UPDATE roles SET name=?, description=?, permissions=? WHERE role_key=?', [next.name, next.description ?? null, next.permissions ?? '{}', key]);
+      return res.affectedRows || 0;
+    },
+    async deleteRole(key){
+      const res = await exec('DELETE FROM roles WHERE role_key=?', [key]);
+      return res.affectedRows || 0;
+    },
+    async countUsersByRole(roleKey){
+      const rows = await exec('SELECT COUNT(*) AS c FROM users WHERE role=?', [roleKey]);
+      const row = rows[0];
+      return row ? Number(row.c ?? row.COUNT) : 0;
     }
   };
 }

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -14,12 +14,22 @@ function createApi(dbh, dialect) {
     dialect,
     async init() {
       await dbh.exec(`
+      CREATE TABLE IF NOT EXISTS roles(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        role_key TEXT UNIQUE NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        permissions TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
       CREATE TABLE IF NOT EXISTS users(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         username TEXT UNIQUE NOT NULL,
         password_hash TEXT NOT NULL,
         role TEXT NOT NULL DEFAULT 'user',
-        created_at TEXT DEFAULT (datetime('now'))
+        created_at TEXT DEFAULT (datetime('now')),
+        FOREIGN KEY(role) REFERENCES roles(role_key) ON UPDATE CASCADE
       );
       CREATE TABLE IF NOT EXISTS servers(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -136,12 +146,36 @@ function createApi(dbh, dialect) {
     async countUsers(){ const r = await dbh.get('SELECT COUNT(*) c FROM users'); return r.c; },
     async createUser(u){
       const { username, password_hash, role = 'user' } = u;
-      const r = await dbh.run('INSERT INTO users(username,password_hash,role) VALUES(?,?,?)',[username,password_hash,role]);
+      const normalizedRole = role || 'user';
+      const r = await dbh.run('INSERT INTO users(username,password_hash,role) VALUES(?,?,?)',[username,password_hash,normalizedRole]);
       return r.lastID;
     },
-    async getUser(id){ return await dbh.get('SELECT * FROM users WHERE id=?',[id]); },
-    async getUserByUsername(u){ return await dbh.get('SELECT * FROM users WHERE username=?',[u]); },
-    async listUsers(){ return await dbh.all('SELECT id,username,role,created_at FROM users ORDER BY id ASC'); },
+    async getUser(id){
+      return await dbh.get(
+        `SELECT u.*, r.name AS role_name, r.permissions AS role_permissions
+         FROM users u
+         LEFT JOIN roles r ON r.role_key = u.role
+         WHERE u.id=?`,
+        [id]
+      );
+    },
+    async getUserByUsername(u){
+      return await dbh.get(
+        `SELECT u.*, r.name AS role_name, r.permissions AS role_permissions
+         FROM users u
+         LEFT JOIN roles r ON r.role_key = u.role
+         WHERE u.username=?`,
+        [u]
+      );
+    },
+    async listUsers(){
+      return await dbh.all(
+        `SELECT u.id, u.username, u.role, u.created_at, r.name AS role_name
+         FROM users u
+         LEFT JOIN roles r ON r.role_key = u.role
+         ORDER BY u.id ASC`
+      );
+    },
     async countAdmins(){ const r = await dbh.get("SELECT COUNT(*) c FROM users WHERE role='admin'"); return r.c; },
     async updateUserPassword(id, hash){ await dbh.run('UPDATE users SET password_hash=? WHERE id=?',[hash,id]); },
     async updateUserRole(id, role){ await dbh.run('UPDATE users SET role=? WHERE id=?',[role,id]); },
@@ -355,6 +389,59 @@ function createApi(dbh, dialect) {
     async deleteServerDiscordIntegration(serverId){
       const result = await dbh.run('DELETE FROM server_discord_integrations WHERE server_id=?',[serverId]);
       return result?.changes ? Number(result.changes) : 0;
+    },
+    async listRoles(){
+      const rows = await dbh.all(`SELECT role_key, name, description, permissions, created_at, updated_at FROM roles ORDER BY name ASC`);
+      return rows.map((row) => ({
+        key: row.role_key,
+        name: row.name,
+        description: row.description,
+        permissions: row.permissions,
+        created_at: row.created_at,
+        updated_at: row.updated_at
+      }));
+    },
+    async getRole(key){
+      const row = await dbh.get(`SELECT role_key, name, description, permissions, created_at, updated_at FROM roles WHERE role_key=?`, [key]);
+      if (!row) return null;
+      return {
+        key: row.role_key,
+        name: row.name,
+        description: row.description,
+        permissions: row.permissions,
+        created_at: row.created_at,
+        updated_at: row.updated_at
+      };
+    },
+    async createRole(role){
+      const now = new Date().toISOString();
+      await dbh.run(
+        `INSERT INTO roles(role_key,name,description,permissions,created_at,updated_at) VALUES(?,?,?,?,?,?)`,
+        [role.key, role.name, role.description ?? null, role.permissions ?? '{}', now, now]
+      );
+    },
+    async updateRole(key, payload){
+      const existing = await this.getRole(key);
+      if (!existing) return 0;
+      const next = {
+        name: typeof payload.name === 'undefined' ? existing.name : payload.name,
+        description: typeof payload.description === 'undefined' ? existing.description : payload.description,
+        permissions: typeof payload.permissions === 'undefined' ? existing.permissions : payload.permissions
+      };
+      const now = new Date().toISOString();
+      const res = await dbh.run(
+        `UPDATE roles SET name=?, description=?, permissions=?, updated_at=? WHERE role_key=?`,
+        [next.name, next.description ?? null, next.permissions ?? '{}', now, key]
+      );
+      return res.changes || 0;
+    },
+    async deleteRole(key){
+      const res = await dbh.run('DELETE FROM roles WHERE role_key=?', [key]);
+      return res.changes || 0;
+    },
+    async countUsersByRole(roleKey){
+      const row = await dbh.get('SELECT COUNT(*) c FROM users WHERE role=?', [roleKey]);
+      return row?.c ? Number(row.c) : 0;
     }
   };
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import bcrypt from 'bcrypt';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import jwt from 'jsonwebtoken';
 import { db, initDb } from './db/index.js';
 import { authMiddleware, signToken, requireAdmin } from './auth.js';
 // index.js
@@ -19,6 +20,15 @@ import {
   rconEventBus
 } from './rcon.js';
 import { fetchRustMapMetadata, downloadRustMapImage } from './rustmaps.js';
+import {
+  normaliseRolePermissions,
+  serialiseRolePermissions,
+  hasGlobalPermission,
+  canAccessServer,
+  filterServersByPermission,
+  filterStatusMapByPermission,
+  describeRoleTemplates
+} from './permissions.js';
 
 
 const __filename = fileURLToPath(import.meta.url);
@@ -32,10 +42,106 @@ const app = express();
 const server = http.createServer(app);
 const io = new IOServer(server, { cors: { origin: process.env.CORS_ORIGIN?.split(',') || '*' } });
 
+io.use(async (socket, next) => {
+  const token = socket.handshake.auth?.token || socket.handshake.query?.token;
+  if (!token) return next(new Error('unauthorized'));
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    const context = await loadUserContext(payload.uid);
+    if (!context) return next(new Error('unauthorized'));
+    socket.data.user = context;
+    next();
+  } catch (err) {
+    next(new Error('unauthorized'));
+  }
+});
+
 const PORT = parseInt(process.env.PORT || '8787', 10);
 const BIND = process.env.BIND || '0.0.0.0';
 const JWT_SECRET = process.env.JWT_SECRET || 'dev';
 const ALLOW_REGISTRATION = (process.env.ALLOW_REGISTRATION || '').toLowerCase() === 'true';
+
+async function loadUserContext(userId) {
+  const numeric = Number(userId);
+  if (!Number.isFinite(numeric)) return null;
+  const row = await db.getUser(numeric);
+  if (!row) return null;
+  const permissions = normaliseRolePermissions(row.role_permissions, row.role);
+  return {
+    id: row.id,
+    username: row.username,
+    role: row.role,
+    roleName: row.role_name || row.role,
+    permissions
+  };
+}
+
+function requireGlobalPermissionMiddleware(permission) {
+  return (req, res, next) => {
+    if (!hasGlobalPermission(req.authUser, permission)) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    next();
+  };
+}
+
+function ensureServerCapability(req, res, capability, param = 'id') {
+  const raw = req.params?.[param];
+  const id = toServerId(raw);
+  if (id == null) {
+    res.status(400).json({ error: 'invalid_id' });
+    return null;
+  }
+  if (!canAccessServer(req.authUser, id, capability)) {
+    res.status(403).json({ error: 'forbidden' });
+    return null;
+  }
+  return id;
+}
+
+function projectRole(row) {
+  if (!row) return null;
+  return {
+    key: row.key,
+    name: row.name,
+    description: row.description,
+    permissions: normaliseRolePermissions(row.permissions, row.key),
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
+const ROLE_KEY_PATTERN = /^[a-z0-9_\-]{3,32}$/i;
+const RESERVED_ROLE_KEYS = new Set(['admin', 'user']);
+
+function normalizeRoleKey(value) {
+  if (typeof value !== 'string') return null;
+  const key = value.trim();
+  if (!ROLE_KEY_PATTERN.test(key)) return null;
+  return key.toLowerCase();
+}
+
+function buildRolePermissionsPayload(body = {}, roleKey = 'default') {
+  const source = body && typeof body.permissions === 'object' ? body.permissions : {};
+  const payload = { ...source };
+  if (source.servers && typeof source.servers === 'object') {
+    payload.servers = { ...source.servers };
+  }
+  if (source.global && typeof source.global === 'object') {
+    payload.global = { ...source.global };
+  }
+  const allowed = body.allowedServers ?? body.allowed ?? body.servers;
+  if (typeof allowed !== 'undefined') {
+    payload.servers = { ...(payload.servers || {}), allowed };
+  }
+  if (typeof body.capabilities !== 'undefined') {
+    payload.servers = { ...(payload.servers || {}), capabilities: body.capabilities };
+  }
+  if (body.global && typeof body.global === 'object') {
+    payload.global = { ...(payload.global || {}), ...body.global };
+  }
+  return serialiseRolePermissions(payload, roleKey);
+}
 
 const toInt = (value, fallback) => {
   const parsed = parseInt(value, 10);
@@ -246,7 +352,7 @@ await fs.mkdir(MAP_GLOBAL_CACHE_DIR, { recursive: true });
 await fs.mkdir(MAP_METADATA_CACHE_DIR, { recursive: true });
 await purgeExpiredMapCaches().catch((err) => console.error('initial map purge failed', err));
 
-const auth = authMiddleware(JWT_SECRET);
+const auth = authMiddleware(JWT_SECRET, { loadUserContext });
 const rconBindings = new Map();
 const statusMap = new Map();
 const serverInfoCache = new Map();
@@ -262,12 +368,21 @@ const steamProfileCache = new Map();
 let monitoring = false;
 let monitorTimer = null;
 
+function broadcastStatusUpdate(serverId, payload) {
+  for (const socket of io.sockets.sockets.values()) {
+    const context = socket.data?.user;
+    if (canAccessServer(context, serverId, 'view')) {
+      socket.emit('status-map', { [serverId]: payload });
+    }
+  }
+}
+
 function recordStatus(id, data) {
   const key = Number(id);
   const payload = { id: key, ...data };
   statusMap.set(key, payload);
   io.to(`srv:${key}`).emit('status', payload);
-  io.emit('status-map', { [key]: payload });
+  broadcastStatusUpdate(key, payload);
   return payload;
 }
 
@@ -1441,8 +1556,10 @@ app.post('/api/login', async (req, res) => {
     if (!row) return res.status(401).json({ error: 'invalid_login' });
     const ok = await bcrypt.compare(password, row.password_hash);
     if (!ok) return res.status(401).json({ error: 'invalid_login' });
+    const permissions = normaliseRolePermissions(row.role_permissions, row.role);
+    const roleName = row.role_name || row.role;
     const token = signToken(row, JWT_SECRET);
-    res.json({ token, username: row.username, role: row.role, id: row.id });
+    res.json({ token, username: row.username, role: row.role, roleName, id: row.id, permissions });
   } catch (e) {
     res.status(500).json({ error: 'db_error' });
   }
@@ -1469,7 +1586,14 @@ app.get('/api/me', auth, async (req, res) => {
   try {
     const row = await db.getUser(req.user.uid);
     if (!row) return res.status(404).json({ error: 'not_found' });
-    res.json({ id: row.id, username: row.username, role: row.role, created_at: row.created_at });
+    res.json({
+      id: row.id,
+      username: row.username,
+      role: row.role,
+      roleName: row.role_name || row.role,
+      permissions: normaliseRolePermissions(row.role_permissions, row.role),
+      created_at: row.created_at
+    });
   } catch (e) {
     res.status(500).json({ error: 'db_error' });
   }
@@ -1525,7 +1649,15 @@ app.post('/api/password', auth, async (req, res) => {
 
 app.get('/api/users', auth, requireAdmin, async (req, res) => {
   try {
-    res.json(await db.listUsers());
+    const rows = await db.listUsers();
+    const payload = rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      role: row.role,
+      roleName: row.role_name || row.role,
+      created_at: row.created_at
+    }));
+    res.json(payload);
   } catch {
     res.status(500).json({ error: 'db_error' });
   }
@@ -1536,13 +1668,15 @@ app.post('/api/users', auth, requireAdmin, async (req, res) => {
   if (!username || !password) return res.status(400).json({ error: 'missing_fields' });
   if (!/^[a-z0-9_\-.]{3,32}$/i.test(username)) return res.status(400).json({ error: 'invalid_username' });
   if (password.length < 8) return res.status(400).json({ error: 'weak_password' });
-  if (!['user', 'admin'].includes(role)) return res.status(400).json({ error: 'invalid_role' });
+  const roleKey = typeof role === 'string' && role.trim() ? role.trim() : 'user';
   try {
+    const roleRecord = await db.getRole(roleKey);
+    if (!roleRecord) return res.status(400).json({ error: 'invalid_role' });
     const existing = await db.getUserByUsername(username);
     if (existing) return res.status(409).json({ error: 'username_taken' });
     const hash = bcrypt.hashSync(password, 10);
-    const id = await db.createUser({ username, password_hash: hash, role });
-    res.status(201).json({ id, username, role });
+    const id = await db.createUser({ username, password_hash: hash, role: roleKey });
+    res.status(201).json({ id, username, role: roleKey, roleName: roleRecord.name });
   } catch (e) {
     res.status(500).json({ error: 'db_error' });
   }
@@ -1552,10 +1686,13 @@ app.patch('/api/users/:id', auth, requireAdmin, async (req, res) => {
   const { role } = req.body || {};
   const id = Number(req.params.id);
   if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
-  if (!role || !['user', 'admin'].includes(role)) return res.status(400).json({ error: 'invalid_role' });
+  const roleKey = typeof role === 'string' && role.trim() ? role.trim() : '';
+  if (!roleKey) return res.status(400).json({ error: 'invalid_role' });
   try {
-    await db.updateUserRole(id, role);
-    res.json({ ok: true });
+    const roleRecord = await db.getRole(roleKey);
+    if (!roleRecord) return res.status(400).json({ error: 'invalid_role' });
+    await db.updateUserRole(id, roleKey);
+    res.json({ ok: true, role: roleKey, roleName: roleRecord.name });
   } catch {
     res.status(500).json({ error: 'db_error' });
   }
@@ -1593,6 +1730,94 @@ app.delete('/api/users/:id', auth, requireAdmin, async (req, res) => {
   }
 });
 
+app.get('/api/roles', auth, async (req, res) => {
+  if (!hasGlobalPermission(req.authUser, 'manageRoles') && !hasGlobalPermission(req.authUser, 'manageUsers')) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  try {
+    const rows = await db.listRoles();
+    const roles = rows.map((row) => projectRole(row));
+    res.json({ roles, templates: describeRoleTemplates() });
+  } catch (err) {
+    console.error('list roles failed', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.post('/api/roles', auth, requireGlobalPermissionMiddleware('manageRoles'), async (req, res) => {
+  const body = req.body || {};
+  const key = normalizeRoleKey(body.key);
+  const nameInput = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!key) return res.status(400).json({ error: 'invalid_role_key' });
+  if (!nameInput) return res.status(400).json({ error: 'invalid_name' });
+  if (RESERVED_ROLE_KEYS.has(key)) return res.status(400).json({ error: 'reserved_role' });
+  const description = typeof body.description === 'string' ? body.description.trim() : null;
+  try {
+    const existing = await db.getRole(key);
+    if (existing) return res.status(409).json({ error: 'role_exists' });
+    const permissions = buildRolePermissionsPayload(body, key);
+    await db.createRole({ key, name: nameInput, description, permissions });
+    const created = await db.getRole(key);
+    res.status(201).json(projectRole(created));
+  } catch (err) {
+    console.error('create role failed', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.patch('/api/roles/:key', auth, requireGlobalPermissionMiddleware('manageRoles'), async (req, res) => {
+  const key = normalizeRoleKey(req.params.key);
+  if (!key) return res.status(400).json({ error: 'invalid_role_key' });
+  const body = req.body || {};
+  const updates = {};
+  if (typeof body.name === 'string') {
+    const trimmed = body.name.trim();
+    if (!trimmed) return res.status(400).json({ error: 'invalid_name' });
+    updates.name = trimmed;
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'description')) {
+    if (body.description === null || body.description === '') updates.description = null;
+    else if (typeof body.description === 'string') updates.description = body.description.trim();
+    else updates.description = String(body.description);
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(body, 'permissions') ||
+    Object.prototype.hasOwnProperty.call(body, 'allowedServers') ||
+    Object.prototype.hasOwnProperty.call(body, 'allowed') ||
+    Object.prototype.hasOwnProperty.call(body, 'servers') ||
+    Object.prototype.hasOwnProperty.call(body, 'capabilities') ||
+    Object.prototype.hasOwnProperty.call(body, 'global')
+  ) {
+    updates.permissions = buildRolePermissionsPayload(body, key);
+  }
+  if (!Object.keys(updates).length) return res.status(400).json({ error: 'no_changes' });
+  try {
+    const changed = await db.updateRole(key, updates);
+    if (!changed) return res.status(404).json({ error: 'not_found' });
+    const role = await db.getRole(key);
+    res.json(projectRole(role));
+  } catch (err) {
+    console.error('update role failed', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
+app.delete('/api/roles/:key', auth, requireGlobalPermissionMiddleware('manageRoles'), async (req, res) => {
+  const key = normalizeRoleKey(req.params.key);
+  if (!key) return res.status(400).json({ error: 'invalid_role_key' });
+  if (RESERVED_ROLE_KEYS.has(key)) return res.status(400).json({ error: 'reserved_role' });
+  try {
+    const count = await db.countUsersByRole(key);
+    if (count > 0) return res.status(400).json({ error: 'role_in_use', users: count });
+    const deleted = await db.deleteRole(key);
+    if (!deleted) return res.status(404).json({ error: 'not_found' });
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error('delete role failed', err);
+    res.status(500).json({ error: 'db_error' });
+  }
+});
+
 // --- Servers CRUD
 app.get('/api/servers', auth, async (req, res) => {
   try {
@@ -1602,27 +1827,28 @@ app.get('/api/servers', auth, async (req, res) => {
       const { password: _pw, ...rest } = row;
       return rest;
     });
-    res.json(sanitized);
+    const filtered = filterServersByPermission(sanitized, req.authUser, 'view');
+    res.json(filtered);
   } catch {
     res.status(500).json({ error: 'db_error' });
   }
 });
 
 app.get('/api/servers/status', auth, (req, res) => {
-  res.json(getStatusSnapshot());
+  res.json(filterStatusMapByPermission(getStatusSnapshot(), req.authUser, 'view'));
 });
 
 app.get('/api/servers/:id/status', auth, (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'view');
+  if (id == null) return;
   const status = statusMap.get(id);
   if (!status) return res.status(404).json({ error: 'not_found' });
   res.json(status);
 });
 
 app.get('/api/servers/:id/discord', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'discord');
+  if (id == null) return;
   if (typeof db.getServerDiscordIntegration !== 'function') {
     return res.status(501).json({ error: 'not_supported' });
   }
@@ -1641,8 +1867,8 @@ app.get('/api/servers/:id/discord', auth, async (req, res) => {
 });
 
 app.post('/api/servers/:id/discord', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'discord');
+  if (id == null) return;
   if (typeof db.saveServerDiscordIntegration !== 'function' || typeof db.getServerDiscordIntegration !== 'function') {
     return res.status(501).json({ error: 'not_supported' });
   }
@@ -1678,8 +1904,8 @@ app.post('/api/servers/:id/discord', auth, async (req, res) => {
 });
 
 app.delete('/api/servers/:id/discord', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'discord');
+  if (id == null) return;
   if (typeof db.deleteServerDiscordIntegration !== 'function') {
     return res.status(501).json({ error: 'not_supported' });
   }
@@ -1698,7 +1924,7 @@ app.delete('/api/servers/:id/discord', auth, async (req, res) => {
   }
 });
 
-app.post('/api/servers', auth, async (req, res) => {
+app.post('/api/servers', auth, requireGlobalPermissionMiddleware('manageServers'), async (req, res) => {
   const { name, host, port, password, tls } = req.body || {};
   if (!name || !host || !port || !password) return res.status(400).json({ error: 'missing_fields' });
   try {
@@ -1711,8 +1937,8 @@ app.post('/api/servers', auth, async (req, res) => {
 });
 
 app.patch('/api/servers/:id', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'manage');
+  if (id == null) return;
   try {
     const updated = await db.updateServer(id, req.body || {});
     if (updated) {
@@ -1726,8 +1952,8 @@ app.patch('/api/servers/:id', auth, async (req, res) => {
 });
 
 app.delete('/api/servers/:id', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'manage');
+  if (id == null) return;
   try {
     const deleted = await db.deleteServer(id);
     closeServerRcon(id);
@@ -1740,8 +1966,8 @@ app.delete('/api/servers/:id', auth, async (req, res) => {
 });
 
 app.get('/api/servers/:id/live-map', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'liveMap');
+  if (id == null) return;
   const logger = createLogger(`live-map:${id}`);
   logger.info('Live map request received');
   try {
@@ -1999,8 +2225,8 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
 });
 
 app.post('/api/servers/:id/live-map/world', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'liveMap');
+  if (id == null) return;
   const { size, seed } = req.body || {};
   const numericSize = Number(size);
   const numericSeed = Number(seed);
@@ -2128,8 +2354,8 @@ app.post('/api/servers/:id/live-map/world', auth, async (req, res) => {
 });
 
 app.post('/api/servers/:id/map-image', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'uploadMap');
+  if (id == null) return;
   const { image, mapKey } = req.body || {};
   if (!image) return res.status(400).json({ error: 'missing_image' });
   const decoded = decodeBase64Image(image);
@@ -2173,8 +2399,8 @@ app.post('/api/servers/:id/map-image', auth, async (req, res) => {
 });
 
 app.get('/api/servers/:id/map-image', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'liveMap');
+  if (id == null) return;
   const logger = createLogger(`map-image:${id}`);
   try {
     let record = await db.getServerMap(id);
@@ -2279,7 +2505,8 @@ app.get('/api/servers/:id/map-image', auth, async (req, res) => {
 
 // --- RCON
 app.post('/api/rcon/:id', auth, async (req, res) => {
-  const { id } = req.params;
+  const id = ensureServerCapability(req, res, 'commands');
+  if (id == null) return;
   const { cmd } = req.body || {};
   if (!cmd) return res.status(400).json({ error: 'missing_cmd' });
   try {
@@ -2306,8 +2533,8 @@ app.get('/api/players', auth, async (req, res) => {
 });
 
 app.get('/api/servers/:id/players', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'players');
+  if (id == null) return;
   const limit = Math.min(parseInt(req.query.limit || '100', 10), 500);
   const offset = parseInt(req.query.offset || '0', 10);
   try {
@@ -2322,8 +2549,8 @@ app.get('/api/servers/:id/players', auth, async (req, res) => {
 
 // --- Player history: /api/servers/:id/player-counts
 app.get('/api/servers/:id/player-counts', auth, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id)) return res.status(400).json({ error: 'invalid_id' });
+  const id = ensureServerCapability(req, res, 'players');
+  if (id == null) return;
 
   const now = Date.now();
   const explicitTo = parseTimestamp(req.query.to) ?? now;
@@ -2394,8 +2621,8 @@ app.patch('/api/servers/:serverId/players/:steamid', auth, async (req, res) => {
   if (typeof db.setServerPlayerDisplayName !== 'function') {
     return res.status(400).json({ error: 'unsupported' });
   }
-  const serverId = Number(req.params.serverId);
-  if (!Number.isFinite(serverId)) return res.status(400).json({ error: 'invalid_server_id' });
+  const serverId = ensureServerCapability(req, res, 'manage', 'serverId');
+  if (serverId == null) return;
 
   const steamid = String(req.params.steamid || '').trim();
   if (!steamid) return res.status(400).json({ error: 'invalid_steamid' });
@@ -2543,10 +2770,14 @@ app.post('/api/steam/sync', auth, async (req, res) => {
 
 // --- sockets
 io.on('connection', (socket) => {
-  socket.emit('status-map', getStatusSnapshot());
+  socket.emit('status-map', filterStatusMapByPermission(getStatusSnapshot(), socket.data?.user, 'view'));
   socket.on('join-server', async (serverId) => {
     const id = Number(serverId);
     if (!Number.isFinite(id)) return;
+    if (!canAccessServer(socket.data?.user, id, 'console')) {
+      socket.emit('error', 'forbidden');
+      return;
+    }
     const row = await db.getServer(id);
     if (!row) return;
     socket.join(`srv:${id}`);

--- a/backend/src/permissions.js
+++ b/backend/src/permissions.js
@@ -1,0 +1,158 @@
+const SERVER_CAPABILITIES = ['view', 'console', 'commands', 'liveMap', 'players', 'manage', 'discord', 'uploadMap'];
+const GLOBAL_PERMISSIONS = ['manageUsers', 'manageServers', 'manageRoles'];
+
+const DEFAULT_TEMPLATE = {
+  servers: {
+    allowed: ['*'],
+    capabilities: Object.fromEntries(SERVER_CAPABILITIES.map((cap) => [cap, true]))
+  },
+  global: {
+    manageUsers: false,
+    manageServers: true,
+    manageRoles: false
+  }
+};
+
+const ADMIN_TEMPLATE = {
+  servers: {
+    allowed: ['*'],
+    capabilities: Object.fromEntries(SERVER_CAPABILITIES.map((cap) => [cap, true]))
+  },
+  global: Object.fromEntries(GLOBAL_PERMISSIONS.map((perm) => [perm, true]))
+};
+
+const ROLE_TEMPLATES = {
+  admin: ADMIN_TEMPLATE,
+  user: DEFAULT_TEMPLATE,
+  default: DEFAULT_TEMPLATE
+};
+
+function cloneTemplate(key) {
+  const template = ROLE_TEMPLATES[key] || ROLE_TEMPLATES.default;
+  return {
+    servers: {
+      allowed: [...(template.servers?.allowed || ['*'])],
+      capabilities: { ...(template.servers?.capabilities || {}) }
+    },
+    global: { ...(template.global || {}) }
+  };
+}
+
+function parsePermissions(raw) {
+  if (!raw) return {};
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === 'object') return raw;
+  return {};
+}
+
+function normaliseAllowed(input, fallback = ['*']) {
+  if (input === '*' || input === 'all') return ['*'];
+  if (Array.isArray(input)) {
+    const out = [];
+    for (const item of input) {
+      if (item === '*' || item === 'all') {
+        return ['*'];
+      }
+      const numeric = Number(item);
+      if (Number.isFinite(numeric)) {
+        out.push(String(Math.trunc(numeric)));
+      } else if (typeof item === 'string' && item.trim()) {
+        out.push(item.trim());
+      }
+    }
+    return out.length ? Array.from(new Set(out)) : [...fallback];
+  }
+  if (input && typeof input === 'object' && Array.isArray(input.allowed)) {
+    return normaliseAllowed(input.allowed, fallback);
+  }
+  return [...fallback];
+}
+
+function normaliseCapabilities(input = {}, fallback = {}) {
+  const out = { ...fallback };
+  for (const cap of SERVER_CAPABILITIES) {
+    if (typeof input[cap] === 'boolean') out[cap] = input[cap];
+  }
+  return out;
+}
+
+function normaliseGlobal(input = {}, fallback = {}) {
+  const out = { ...fallback };
+  for (const perm of GLOBAL_PERMISSIONS) {
+    if (typeof input[perm] === 'boolean') out[perm] = input[perm];
+  }
+  return out;
+}
+
+export function normaliseRolePermissions(raw, roleKey = 'default') {
+  const parsed = parsePermissions(raw);
+  const base = cloneTemplate(roleKey);
+  const serversInput = parsed.servers || parsed.server || {};
+  base.servers.allowed = normaliseAllowed(serversInput.allowed ?? serversInput, base.servers.allowed);
+  base.servers.capabilities = normaliseCapabilities(serversInput.capabilities || parsed.capabilities || {}, base.servers.capabilities);
+  base.global = normaliseGlobal(parsed.global || {}, base.global);
+  return base;
+}
+
+export function serialiseRolePermissions(permissions, roleKey = 'default') {
+  const normalised = normaliseRolePermissions(permissions, roleKey);
+  return JSON.stringify(normalised);
+}
+
+export function hasGlobalPermission(context, permission) {
+  if (!permission) return true;
+  return !!context?.permissions?.global?.[permission];
+}
+
+function isAllowedServer(allowed, serverId) {
+  if (!Array.isArray(allowed) || !allowed.length) return false;
+  if (allowed.includes('*')) return true;
+  const idNum = Number(serverId);
+  const idStr = String(serverId);
+  return allowed.some((value) => {
+    if (value === '*') return true;
+    if (String(value) === idStr) return true;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric === idNum;
+  });
+}
+
+export function canAccessServer(context, serverId, capability = 'view') {
+  if (!context?.permissions) return false;
+  const allowed = context.permissions.servers?.allowed;
+  if (!isAllowedServer(allowed, serverId)) return false;
+  if (!capability) return true;
+  const caps = context.permissions.servers?.capabilities;
+  if (!caps) return false;
+  if (caps['*']) return true;
+  return !!caps[capability];
+}
+
+export function filterServersByPermission(servers = [], context, capability = 'view') {
+  if (!Array.isArray(servers)) return [];
+  return servers.filter((server) => canAccessServer(context, server?.id ?? server?.server_id ?? server?.serverId, capability));
+}
+
+export function filterStatusMapByPermission(statusMap = {}, context, capability = 'view') {
+  const result = {};
+  if (!statusMap || typeof statusMap !== 'object') return result;
+  for (const [key, value] of Object.entries(statusMap)) {
+    if (canAccessServer(context, key, capability)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function describeRoleTemplates() {
+  return {
+    serverCapabilities: [...SERVER_CAPABILITIES],
+    globalPermissions: [...GLOBAL_PERMISSIONS]
+  };
+}

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -32,16 +32,33 @@
   const svTLS = $('#svTLS');
   const btnSend = $('#btnSend');
   const cmdInput = $('#cmd');
+  const cmdInputDefaultPlaceholder = cmdInput?.getAttribute('placeholder') || '';
   const loginUsername = $('#username');
   const loginPassword = $('#password');
   const btnLogin = $('#btnLogin');
   const regUsername = $('#regUsername');
   const regPassword = $('#regPassword');
   const regConfirm = $('#regConfirm');
+  const userCreateSection = $('#userCreateSection');
   const newUserName = $('#newUserName');
   const newUserPassword = $('#newUserPassword');
   const newUserRole = $('#newUserRole');
   const btnCreateUser = $('#btnCreateUser');
+  const roleManager = $('#roleManager');
+  const roleEditor = $('#roleEditor');
+  const rolesHeader = $('#rolesHeader');
+  const roleSelect = $('#roleSelect');
+  const roleNameInput = $('#roleName');
+  const roleDescriptionInput = $('#roleDescription');
+  const roleServersInput = $('#roleServers');
+  const roleCapabilitiesFieldset = $('#roleCapabilities');
+  const roleGlobalFieldset = $('#roleGlobalPermissions');
+  const newRoleKey = $('#newRoleKey');
+  const newRoleName = $('#newRoleName');
+  const btnCreateRole = $('#btnCreateRole');
+  const btnSaveRole = $('#btnSaveRole');
+  const btnDeleteRole = $('#btnDeleteRole');
+  const roleFeedback = $('#roleFeedback');
   const quickCommandsEl = $('#quickCommands');
   const rustMapsKeyInput = $('#rustMapsKey');
   const btnSaveSettings = $('#btnSaveSettings');
@@ -86,12 +103,15 @@
   const userDetailsRoleBadge = $('#userDetailsRoleBadge');
   const userDetailsCreated = $('#userDetailsCreated');
   const userDetailsId = $('#userDetailsId');
-  const userDetailsToggleRole = $('#userDetailsToggleRole');
+  const userDetailsRoleSelect = $('#userDetailsRoleSelect');
+  const userDetailsSaveRole = $('#userDetailsSaveRole');
   const userDetailsResetPassword = $('#userDetailsResetPassword');
   const userDetailsDelete = $('#userDetailsDelete');
   const userDetailsSelfNotice = $('#userDetailsSelfNotice');
+  const userDetailsRoleStatus = $('#userDetailsRoleStatus');
 
   const workspaceViewSections = Array.from(document.querySelectorAll('.workspace-view'));
+  const workspaceViewSectionMap = new Map(workspaceViewSections.map((section) => [section.dataset.view, section]));
   const workspaceViewButtons = workspaceMenu ? Array.from(workspaceMenu.querySelectorAll('.menu-tab')) : [];
   const workspaceViewDefault = 'players';
   let activeWorkspaceView = workspaceViewDefault;
@@ -116,23 +136,38 @@
   });
 
   function setWorkspaceView(nextView = workspaceViewDefault) {
-    const available = new Set(workspaceViewButtons.map((btn) => btn.dataset.view));
-    const target = available.has(nextView) ? nextView : workspaceViewDefault;
+    const visibleButtons = workspaceViewButtons.filter((btn) => !btn.classList.contains('permission-hidden') && !btn.disabled);
+    if (visibleButtons.length === 0) {
+      activeWorkspaceView = workspaceViewDefault;
+      workspaceViewSections.forEach((section) => {
+        section.classList.remove('active');
+        section.setAttribute('aria-hidden', 'true');
+      });
+      return;
+    }
+    const available = new Set(visibleButtons.map((btn) => btn.dataset.view));
+    let target = available.has(nextView) ? nextView : visibleButtons[0]?.dataset.view || workspaceViewDefault;
+    if (!available.has(target)) target = visibleButtons[0]?.dataset.view || workspaceViewDefault;
     activeWorkspaceView = target;
     workspaceViewButtons.forEach((btn) => {
-      const match = btn.dataset.view === target;
+      const allowed = !btn.classList.contains('permission-hidden') && !btn.disabled;
+      const match = allowed && btn.dataset.view === target;
       btn.classList.toggle('active', match);
       btn.setAttribute('aria-pressed', match ? 'true' : 'false');
     });
     workspaceViewSections.forEach((section) => {
-      const match = section.dataset.view === target;
+      const allowed = !section.classList.contains('permission-hidden');
+      const match = allowed && section.dataset.view === target;
       section.classList.toggle('active', match);
       section.setAttribute('aria-hidden', match ? 'false' : 'true');
     });
   }
 
   workspaceViewButtons.forEach((btn) => {
-    btn.addEventListener('click', () => setWorkspaceView(btn.dataset.view));
+    btn.addEventListener('click', () => {
+      if (btn.disabled || btn.classList.contains('permission-hidden')) return;
+      setWorkspaceView(btn.dataset.view);
+    });
   });
 
   if (workspaceViewSections.length) {
@@ -148,13 +183,52 @@
     allowRegistration: false,
     statusTimer: null,
     settings: {},
-    activePanel: 'dashboard'
+    activePanel: 'dashboard',
+    roles: [],
+    roleTemplates: { serverCapabilities: [], globalPermissions: [] }
   };
 
   let socket = null;
   let addServerPinned = false;
   let activeUserDetails = null;
   let lastUserDetailsTrigger = null;
+  let activeRoleEditKey = null;
+
+  function currentUserPermissions() {
+    return state.currentUser?.permissions || {};
+  }
+
+  function hasGlobalPermission(permission) {
+    return !!currentUserPermissions().global?.[permission];
+  }
+
+  function serverPermissionConfig() {
+    return currentUserPermissions().servers || {};
+  }
+
+  function hasServerCapability(capability) {
+    const caps = serverPermissionConfig().capabilities || {};
+    return !!caps[capability];
+  }
+
+  function allowedServerList() {
+    if (!state.currentUser) return [];
+    const allowed = serverPermissionConfig().allowed;
+    if (!Array.isArray(allowed) || allowed.length === 0) return ['*'];
+    return allowed;
+  }
+
+  function canAccessServerId(serverId) {
+    const allowed = allowedServerList();
+    if (allowed.includes('*')) return true;
+    const idNum = Number(serverId);
+    const idStr = String(serverId);
+    return allowed.some((entry) => {
+      if (String(entry) === idStr) return true;
+      const numeric = Number(entry);
+      return Number.isFinite(numeric) && numeric === idNum;
+    });
+  }
 
   const userDetailsDateFormatter = new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
@@ -187,7 +261,15 @@
   }
 
   function formatUserRole(role) {
-    return role === 'admin' ? 'Administrator' : 'User';
+    if (!role) return '—';
+    if (typeof role === 'object') {
+      if (role.roleName) return role.roleName;
+      if (role.name) return role.name;
+      return formatUserRole(role.role);
+    }
+    const value = String(role).trim();
+    if (!value) return '—';
+    return value.charAt(0).toUpperCase() + value.slice(1);
   }
 
   function formatUserJoined(value) {
@@ -214,15 +296,18 @@
         ? 'Signed in with this account'
         : 'Review access and credentials';
     }
-    if (userDetailsRole) userDetailsRole.textContent = formatUserRole(user.role);
-    if (userDetailsRoleBadge) userDetailsRoleBadge.textContent = user.role === 'admin' ? 'Admin' : 'User';
+    const roleLabel = formatUserRole(user);
+    if (userDetailsRole) userDetailsRole.textContent = roleLabel;
+    if (userDetailsRoleBadge) userDetailsRoleBadge.textContent = roleLabel;
     if (userDetailsCreated) userDetailsCreated.textContent = formatUserJoined(user.created_at);
     if (userDetailsId) userDetailsId.textContent = user.id != null ? String(user.id) : '—';
     if (userDetailsSelfNotice) userDetailsSelfNotice.classList.toggle('hidden', !isSelf);
-    if (userDetailsToggleRole) {
-      userDetailsToggleRole.textContent = user.role === 'admin' ? 'Make user' : 'Promote to admin';
-      userDetailsToggleRole.disabled = isSelf;
+    if (userDetailsRoleSelect) {
+      userDetailsRoleSelect.value = user.role || '';
+      userDetailsRoleSelect.disabled = isSelf || !hasGlobalPermission('manageUsers');
     }
+    if (userDetailsSaveRole) userDetailsSaveRole.disabled = isSelf || !hasGlobalPermission('manageUsers');
+    hideNotice(userDetailsRoleStatus);
     if (userDetailsResetPassword) userDetailsResetPassword.disabled = !state.currentUser || user.id === state.currentUser.id;
     if (userDetailsDelete) userDetailsDelete.disabled = isSelf;
   }
@@ -254,18 +339,33 @@
     lastUserDetailsTrigger = null;
   }
 
-  async function handleUserDetailsRoleToggle() {
-    if (!activeUserDetails) return;
-    const targetRole = activeUserDetails.role === 'admin' ? 'user' : 'admin';
+  function findRoleDefinition(key) {
+    if (!key) return null;
+    return state.roles.find((role) => role.key === key) || null;
+  }
+
+  async function handleUserDetailsRoleSave() {
+    if (!activeUserDetails || !userDetailsRoleSelect) return;
+    if (!hasGlobalPermission('manageUsers')) return;
+    const selected = userDetailsRoleSelect.value;
+    if (!selected || selected === activeUserDetails.role) {
+      showNotice(userDetailsRoleStatus, 'Select a different role before updating.', 'error');
+      return;
+    }
     try {
-      await api(`/users/${activeUserDetails.id}`, { role: targetRole }, 'PATCH');
-      showNotice(userFeedback, 'Updated role for ' + activeUserDetails.username, 'success');
-      activeUserDetails = { ...activeUserDetails, role: targetRole };
+      await api(`/users/${activeUserDetails.id}`, { role: selected }, 'PATCH');
+      const roleDef = findRoleDefinition(selected);
+      activeUserDetails = {
+        ...activeUserDetails,
+        role: selected,
+        roleName: roleDef?.name || selected
+      };
+      showNotice(userDetailsRoleStatus, 'Role updated successfully.', 'success');
       renderUserDetails(activeUserDetails);
-      loadUsers();
+      await loadUsers();
     } catch (err) {
       if (errorCode(err) === 'unauthorized') handleUnauthorized();
-      else showNotice(userFeedback, describeError(err), 'error');
+      else showNotice(userDetailsRoleStatus, describeError(err), 'error');
     }
   }
 
@@ -317,7 +417,7 @@
     }
   });
 
-  userDetailsToggleRole?.addEventListener('click', handleUserDetailsRoleToggle);
+  userDetailsSaveRole?.addEventListener('click', handleUserDetailsRoleSave);
   userDetailsResetPassword?.addEventListener('click', handleUserDetailsPasswordReset);
   userDetailsDelete?.addEventListener('click', handleUserDetailsDelete);
 
@@ -411,6 +511,80 @@
   registerQuickCommand({ id: 'cmd-serverinfo', label: 'serverinfo', command: 'serverinfo', order: 20 });
   registerQuickCommand({ id: 'cmd-say', label: 'say', command: 'say "Hello from panel"', order: 30 });
   registerQuickCommand({ id: 'cmd-playerlist', label: 'playerlist', command: 'playerlist', order: 40 });
+
+  function updateWorkspaceCapabilityVisibility() {
+    const visibleViews = [];
+    workspaceViewButtons.forEach((btn) => {
+      const view = btn.dataset.view;
+      const capability = btn.dataset.capability || '';
+      const allowed = !capability || hasServerCapability(capability);
+      btn.classList.toggle('permission-hidden', !allowed);
+      btn.classList.toggle('hidden', !allowed);
+      btn.disabled = !allowed;
+      btn.setAttribute('aria-hidden', allowed ? 'false' : 'true');
+      if (allowed) visibleViews.push(view);
+      const section = workspaceViewSectionMap.get(view);
+      if (section) {
+        section.classList.toggle('permission-hidden', !allowed);
+        section.classList.toggle('hidden', !allowed);
+        if (!allowed) section.setAttribute('aria-hidden', 'true');
+      }
+    });
+    return visibleViews;
+  }
+
+  function applyPermissionGates() {
+    const canManageServers = hasGlobalPermission('manageServers');
+    if (addServerPrompt) {
+      addServerPrompt.classList.toggle('hidden', !canManageServers);
+      addServerPrompt.setAttribute('aria-hidden', canManageServers ? 'false' : 'true');
+      if (!canManageServers) setAddServerPromptState(false);
+    }
+    if (!canManageServers) {
+      hideAddServerCard({ force: true });
+      addServerCard?.classList.add('hidden');
+    } else if (addServerPinned && addServerCard) {
+      addServerCard.classList.remove('hidden');
+    }
+    if (btnAddServer) btnAddServer.disabled = !canManageServers;
+    [svName, svHost, svPort, svPass, svTLS].forEach((el) => {
+      if (el) el.disabled = !canManageServers;
+    });
+
+    const canManageUsers = hasGlobalPermission('manageUsers');
+    if (userCreateSection) userCreateSection.classList.toggle('hidden', !canManageUsers);
+    if (newUserName) newUserName.disabled = !canManageUsers;
+    if (newUserPassword) newUserPassword.disabled = !canManageUsers;
+    if (btnCreateUser) btnCreateUser.disabled = !canManageUsers;
+    if (newUserRole) newUserRole.disabled = !canManageUsers || !state.roles.length;
+
+    const hasConsole = hasServerCapability('console');
+    const hasCommands = hasServerCapability('commands');
+    if (cmdInput) {
+      cmdInput.disabled = !hasCommands;
+      cmdInput.placeholder = hasCommands ? cmdInputDefaultPlaceholder : 'Commands unavailable for your role.';
+      if (!hasCommands) cmdInput.value = '';
+    }
+    if (btnSend) btnSend.disabled = !hasCommands;
+    if (quickCommandsEl) {
+      quickCommandsEl.classList.toggle('hidden', !hasCommands);
+      quickCommandsEl.setAttribute('aria-hidden', hasCommands ? 'false' : 'true');
+      quickCommandsEl.querySelectorAll('button').forEach((btn) => { btn.disabled = !hasCommands; });
+    }
+    if (btnClearConsole) btnClearConsole.disabled = !hasConsole;
+
+    const visibleViews = updateWorkspaceCapabilityVisibility();
+    if (visibleViews.includes(activeWorkspaceView)) {
+      setWorkspaceView(activeWorkspaceView);
+    } else {
+      setWorkspaceView(visibleViews[0] || workspaceViewDefault);
+    }
+
+    moduleBus.emit('permissions:updated', {
+      permissions: currentUserPermissions(),
+      allowedServers: allowedServerList()
+    });
+  }
 
   function switchPanel(panel = 'dashboard') {
     state.activePanel = panel;
@@ -513,6 +687,12 @@
     playerlist_failed: 'The server did not return a live player list.',
     missing_command: 'Provide a command before sending.',
     no_server_selected: 'Select a server before sending commands.',
+    forbidden: 'You do not have permission to perform this action.',
+    invalid_role_key: 'Provide a valid role key (letters, numbers, hyphens or underscores).',
+    invalid_name: 'Role name cannot be empty.',
+    reserved_role: 'This role key is reserved by the system.',
+    role_exists: 'A role with that key already exists.',
+    role_in_use: 'This role is currently assigned to one or more users.',
     invalid_payload: 'The request payload was not accepted.',
     missing_image: 'Choose an image before uploading.',
     invalid_image: 'The selected image could not be processed.',
@@ -725,6 +905,7 @@
 
   function showAddServerCard(options = {}) {
     if (!addServerCard) return;
+    if (!hasGlobalPermission('manageServers')) return;
     const pinned = !!options.pinned;
     if (pinned) addServerPinned = true;
     addServerCard.classList.remove('hidden');
@@ -742,6 +923,7 @@
 
   function toggleAddServerCardVisibility() {
     if (!addServerCard) return;
+    if (!hasGlobalPermission('manageServers')) return;
     const willOpen = addServerCard.classList.contains('hidden');
     addServerPinned = willOpen;
     addServerCard.classList.toggle('hidden', !willOpen);
@@ -752,7 +934,7 @@
   function leaveCurrentServer(reason = 'close') {
     const previous = state.currentServerId;
     if (previous == null) return;
-    if (socket?.connected) {
+    if (socket?.connected && hasServerCapability('console')) {
       try { socket.emit('leave-server', previous); }
       catch { /* ignore */ }
     }
@@ -1001,10 +1183,15 @@
   function ensureSocket() {
     if (socket || !state.API) return socket;
     const socketBase = resolveSocketBase();
-    socket = io(socketBase || undefined, { transports: ['websocket'] });
+    socket = io(socketBase || undefined, {
+      transports: ['websocket'],
+      auth: { token: state.TOKEN || undefined }
+    });
     socket.on('connect', () => {
       ui.log('Realtime link established.');
-      if (state.currentServerId != null) socket.emit('join-server', state.currentServerId);
+      if (state.currentServerId != null && hasServerCapability('console') && canAccessServerId(state.currentServerId)) {
+        socket.emit('join-server', state.currentServerId);
+      }
       refreshServerStatuses().catch(() => {});
     });
     socket.on('disconnect', () => {
@@ -1205,10 +1392,21 @@
     details.className = 'server-card-details';
     const actions = document.createElement('div');
     actions.className = 'server-card-actions';
-    const editBtn = document.createElement('button');
-    editBtn.type = 'button';
-    editBtn.className = 'ghost small';
-    editBtn.textContent = 'Edit server';
+    const canManageServer = hasGlobalPermission('manageServers');
+    let editForm = null;
+    let editBtn = null;
+    let removeBtn = null;
+    let cancelBtn = null;
+    let saveBtn = null;
+    let nameInput = null;
+    let hostInput = null;
+    let portInput = null;
+    let passwordInput = null;
+    let tlsInput = null;
+    let feedback = null;
+    let editOpen = false;
+    let toggleEdit = () => {};
+
     const openBtn = document.createElement('button');
     openBtn.type = 'button';
     openBtn.className = 'accent small';
@@ -1217,213 +1415,217 @@
       ev.stopPropagation();
       connectServer(server.id);
     });
-    actions.appendChild(editBtn);
+
+    if (canManageServer) {
+      editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'ghost small';
+      editBtn.textContent = 'Edit server';
+      actions.appendChild(editBtn);
+
+      editForm = document.createElement('form');
+      editForm.className = 'server-card-edit hidden';
+      editForm.id = `server-edit-${server.id}`;
+      editBtn.setAttribute('aria-controls', editForm.id);
+      editBtn.setAttribute('aria-expanded', 'false');
+      const formGrid = document.createElement('div');
+      formGrid.className = 'grid2 stack-sm';
+      nameInput = document.createElement('input');
+      nameInput.placeholder = 'Name';
+      hostInput = document.createElement('input');
+      hostInput.placeholder = 'Host/IP';
+      portInput = document.createElement('input');
+      portInput.type = 'number';
+      portInput.min = '1';
+      portInput.placeholder = 'RCON Port';
+      passwordInput = document.createElement('input');
+      passwordInput.type = 'password';
+      passwordInput.placeholder = 'Leave blank to keep current password';
+      formGrid.appendChild(nameInput);
+      formGrid.appendChild(hostInput);
+      formGrid.appendChild(portInput);
+      formGrid.appendChild(passwordInput);
+      const tlsCheckboxLabel = document.createElement('label');
+      tlsCheckboxLabel.className = 'inline';
+      tlsInput = document.createElement('input');
+      tlsInput.type = 'checkbox';
+      tlsCheckboxLabel.appendChild(tlsInput);
+      tlsCheckboxLabel.appendChild(document.createTextNode(' Use TLS (wss)'));
+      const removeRow = document.createElement('div');
+      removeRow.className = 'row remove-row';
+      removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'ghost danger';
+      removeBtn.textContent = 'Remove server';
+      removeRow.appendChild(removeBtn);
+
+      const formRow = document.createElement('div');
+      formRow.className = 'row';
+      cancelBtn = document.createElement('button');
+      cancelBtn.type = 'button';
+      cancelBtn.className = 'ghost';
+      cancelBtn.textContent = 'Cancel';
+      saveBtn = document.createElement('button');
+      saveBtn.type = 'submit';
+      saveBtn.className = 'accent';
+      saveBtn.textContent = 'Save changes';
+      formRow.appendChild(cancelBtn);
+      formRow.appendChild(saveBtn);
+      feedback = document.createElement('p');
+      feedback.className = 'server-edit-feedback hidden';
+      editForm.appendChild(formGrid);
+      editForm.appendChild(tlsCheckboxLabel);
+      editForm.appendChild(removeRow);
+      editForm.appendChild(formRow);
+      editForm.appendChild(feedback);
+
+      const showFeedback = (message = '', variant = '') => {
+        feedback.textContent = message;
+        feedback.classList.remove('hidden', 'error', 'success');
+        if (!message) {
+          feedback.classList.add('hidden');
+          return;
+        }
+        if (variant) feedback.classList.add(variant);
+      };
+
+      const resetEditInputs = () => {
+        const data = entry.data || {};
+        nameInput.value = data.name || '';
+        hostInput.value = data.host || '';
+        portInput.value = data.port != null ? String(data.port) : '';
+        tlsInput.checked = !!data.tls;
+        passwordInput.value = '';
+      };
+
+      toggleEdit = (force) => {
+        const next = typeof force === 'boolean' ? force : !editOpen;
+        if (next === editOpen) return;
+        editOpen = next;
+        if (next) {
+          resetEditInputs();
+          showFeedback('');
+          editForm.classList.remove('hidden');
+          editBtn.textContent = 'Close editor';
+          editBtn.setAttribute('aria-expanded', 'true');
+          card.classList.add('editing');
+          nameInput.focus();
+        } else {
+          editForm.classList.add('hidden');
+          editBtn.textContent = 'Edit server';
+          resetEditInputs();
+          editBtn.setAttribute('aria-expanded', 'false');
+          card.classList.remove('editing');
+        }
+      };
+
+      cancelBtn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        showFeedback('');
+        toggleEdit(false);
+      });
+
+      removeBtn.addEventListener('click', async (ev) => {
+        ev.preventDefault();
+        const label = entry.data?.name || server.name || `Server #${server.id}`;
+        if (!confirm(`Remove ${label}? This cannot be undone.`)) return;
+        removeBtn.disabled = true;
+        cancelBtn.disabled = true;
+        saveBtn.disabled = true;
+        showFeedback('Removing…');
+        try {
+          await api(`/servers/${server.id}`, null, 'DELETE');
+          ui.log('Server removed: ' + label);
+          const wasActive = state.currentServerId === server.id;
+          toggleEdit(false);
+          state.serverItems.delete(String(server.id));
+          card.remove();
+          highlightSelectedServer();
+          moduleBus.emit('servers:updated', { servers: getServerList() });
+          if (wasActive) hideWorkspace('remove');
+          await refreshServers();
+        } catch (err) {
+          if (errorCode(err) === 'unauthorized') {
+            handleUnauthorized();
+          } else {
+            showFeedback(describeError(err), 'error');
+          }
+        } finally {
+          removeBtn.disabled = false;
+          cancelBtn.disabled = false;
+          saveBtn.disabled = false;
+        }
+      });
+
+      editBtn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        toggleEdit(!editOpen);
+        ev.stopImmediatePropagation();
+      });
+
+      editForm.addEventListener('submit', async (ev) => {
+        ev.preventDefault();
+        const name = nameInput.value.trim();
+        const host = hostInput.value.trim();
+        const port = parseInt(portInput.value || '0', 10);
+        const password = passwordInput.value.trim();
+        const useTls = !!tlsInput.checked;
+        if (!name || !host || !Number.isFinite(port) || port <= 0) {
+          showFeedback(describeError('missing_fields'), 'error');
+          return;
+        }
+        const payload = { name, host, port, tls: useTls };
+        if (password) payload.password = password;
+        saveBtn.disabled = true;
+        cancelBtn.disabled = true;
+        showFeedback('Saving…');
+        try {
+          await api(`/servers/${server.id}`, payload, 'PATCH');
+          entry.data = { ...entry.data, name, host, port, tls: useTls ? 1 : 0 };
+          nameEl.textContent = name;
+          metaEl.textContent = `${host}:${port}${useTls ? ' · TLS' : ''}`;
+          ui.log('Server updated: ' + name);
+          showFeedback('Saved.', 'success');
+          setTimeout(() => toggleEdit(false), 700);
+        } catch (err) {
+          if (errorCode(err) === 'unauthorized') {
+            handleUnauthorized();
+          } else {
+            showFeedback(describeError(err), 'error');
+          }
+        } finally {
+          saveBtn.disabled = false;
+          cancelBtn.disabled = false;
+          passwordInput.value = '';
+        }
+      });
+    }
+
     actions.appendChild(openBtn);
     foot.appendChild(details);
     foot.appendChild(actions);
 
-    const editForm = document.createElement('form');
-    editForm.className = 'server-card-edit hidden';
-    editForm.id = `server-edit-${server.id}`;
-    editBtn.setAttribute('aria-controls', editForm.id);
-    editBtn.setAttribute('aria-expanded', 'false');
-    const formGrid = document.createElement('div');
-    formGrid.className = 'grid2 stack-sm';
-    const nameInput = document.createElement('input');
-    nameInput.placeholder = 'Name';
-    const hostInput = document.createElement('input');
-    hostInput.placeholder = 'Host/IP';
-    const portInput = document.createElement('input');
-    portInput.type = 'number';
-    portInput.min = '1';
-    portInput.placeholder = 'RCON Port';
-    const passwordInput = document.createElement('input');
-    passwordInput.type = 'password';
-    passwordInput.placeholder = 'Leave blank to keep current password';
-    formGrid.appendChild(nameInput);
-    formGrid.appendChild(hostInput);
-    formGrid.appendChild(portInput);
-    formGrid.appendChild(passwordInput);
-    const tlsCheckboxLabel = document.createElement('label');
-    tlsCheckboxLabel.className = 'inline';
-    const tlsInput = document.createElement('input');
-    tlsInput.type = 'checkbox';
-    tlsCheckboxLabel.appendChild(tlsInput);
-    tlsCheckboxLabel.appendChild(document.createTextNode(' Use TLS (wss)'));
-    const removeRow = document.createElement('div');
-    removeRow.className = 'row remove-row';
-    const removeBtn = document.createElement('button');
-    removeBtn.type = 'button';
-    removeBtn.className = 'ghost danger';
-    removeBtn.textContent = 'Remove server';
-    removeRow.appendChild(removeBtn);
-
-    const formRow = document.createElement('div');
-    formRow.className = 'row';
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'ghost';
-    cancelBtn.textContent = 'Cancel';
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'submit';
-    saveBtn.className = 'accent';
-    saveBtn.textContent = 'Save changes';
-    formRow.appendChild(cancelBtn);
-    formRow.appendChild(saveBtn);
-    const feedback = document.createElement('p');
-    feedback.className = 'server-edit-feedback hidden';
-    editForm.appendChild(formGrid);
-    editForm.appendChild(tlsCheckboxLabel);
-    editForm.appendChild(removeRow);
-    editForm.appendChild(formRow);
-    editForm.appendChild(feedback);
-
-    function showFeedback(message = '', variant = '') {
-      feedback.textContent = message;
-      feedback.classList.remove('hidden', 'error', 'success');
-      if (!message) {
-        feedback.classList.add('hidden');
-        return;
-      }
-      if (variant) feedback.classList.add(variant);
-    }
-
-    function resetEditInputs() {
-      const data = entry.data || {};
-      nameInput.value = data.name || '';
-      hostInput.value = data.host || '';
-      portInput.value = data.port != null ? String(data.port) : '';
-      tlsInput.checked = !!data.tls;
-      passwordInput.value = '';
-    }
-
-    let editOpen = false;
-    function toggleEdit(force) {
-      const next = typeof force === 'boolean' ? force : !editOpen;
-      if (next === editOpen) return;
-      editOpen = next;
-      if (next) {
-        resetEditInputs();
-        showFeedback('');
-        editForm.classList.remove('hidden');
-        editBtn.textContent = 'Close editor';
-        editBtn.setAttribute('aria-expanded', 'true');
-        card.classList.add('editing');
-        nameInput.focus();
-      } else {
-        editForm.classList.add('hidden');
-        editBtn.textContent = 'Edit server';
-        resetEditInputs();
-        editBtn.setAttribute('aria-expanded', 'false');
-        card.classList.remove('editing');
-      }
-    }
-
-    cancelBtn.addEventListener('click', (ev) => {
-      ev.preventDefault();
-      showFeedback('');
-      toggleEdit(false);
-    });
-
-    removeBtn.addEventListener('click', async (ev) => {
-      ev.preventDefault();
-      const label = entry.data?.name || server.name || `Server #${server.id}`;
-      if (!confirm(`Remove ${label}? This cannot be undone.`)) return;
-      removeBtn.disabled = true;
-      cancelBtn.disabled = true;
-      saveBtn.disabled = true;
-      showFeedback('Removing…');
-      try {
-        await api(`/servers/${server.id}`, null, 'DELETE');
-        ui.log('Server removed: ' + label);
-        const wasActive = state.currentServerId === server.id;
-        toggleEdit(false);
-        state.serverItems.delete(String(server.id));
-        card.remove();
-        highlightSelectedServer();
-        moduleBus.emit('servers:updated', { servers: getServerList() });
-        if (wasActive) hideWorkspace('remove');
-        await refreshServers();
-      } catch (err) {
-        if (errorCode(err) === 'unauthorized') {
-          handleUnauthorized();
-        } else {
-          showFeedback(describeError(err), 'error');
-        }
-      } finally {
-        removeBtn.disabled = false;
-        cancelBtn.disabled = false;
-        saveBtn.disabled = false;
-      }
-    });
-
-    editBtn.addEventListener('click', (ev) => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      if (!editOpen) {
-        toggleEdit(true);
-      } else {
-        toggleEdit(false);
-      }
-      ev.stopImmediatePropagation();
-    });
-
-    editForm.addEventListener('submit', async (ev) => {
-      ev.preventDefault();
-      const name = nameInput.value.trim();
-      const host = hostInput.value.trim();
-      const port = parseInt(portInput.value || '0', 10);
-      const password = passwordInput.value.trim();
-      const useTls = !!tlsInput.checked;
-      if (!name || !host || !Number.isFinite(port) || port <= 0) {
-        showFeedback(describeError('missing_fields'), 'error');
-        return;
-      }
-      const payload = { name, host, port, tls: useTls };
-      if (password) payload.password = password;
-      saveBtn.disabled = true;
-      cancelBtn.disabled = true;
-      showFeedback('Saving…');
-      try {
-        await api(`/servers/${server.id}`, payload, 'PATCH');
-        entry.data = { ...entry.data, name, host, port, tls: useTls ? 1 : 0 };
-        nameEl.textContent = name;
-        metaEl.textContent = `${host}:${port}${useTls ? ' · TLS' : ''}`;
-        ui.log('Server updated: ' + name);
-        showFeedback('Saved.', 'success');
-        setTimeout(() => toggleEdit(false), 700);
-      } catch (err) {
-        if (errorCode(err) === 'unauthorized') {
-          handleUnauthorized();
-        } else {
-          showFeedback(describeError(err), 'error');
-        }
-      } finally {
-        saveBtn.disabled = false;
-        cancelBtn.disabled = false;
-        passwordInput.value = '';
-      }
-    });
-
     card.addEventListener('click', (ev) => {
       const target = ev.target instanceof Element ? ev.target : null;
-      if (target && (target.closest('.server-card-actions') || target.closest('.server-card-edit'))) {
+      if (target && (target.closest('.server-card-actions') || (canManageServer && target.closest('.server-card-edit')))) {
         return;
       }
-      if (editOpen) return;
+      if (canManageServer && editOpen) return;
       connectServer(server.id);
     });
 
     card.addEventListener('keydown', (ev) => {
       if ((ev.key === 'Enter' || ev.key === ' ') && ev.target === card) {
         ev.preventDefault();
+        if (canManageServer && editOpen) return;
         connectServer(server.id);
       }
     });
 
     card.appendChild(mainRow);
     card.appendChild(foot);
-    card.appendChild(editForm);
+    if (editForm) card.appendChild(editForm);
     if (addServerPrompt && addServerPrompt.parentElement === serversEl) {
       serversEl.insertBefore(card, addServerPrompt);
     } else {
@@ -1481,6 +1683,10 @@
     if (!Number.isFinite(numericId)) return;
     const entry = state.serverItems.get(String(numericId));
     if (!entry) return;
+    if (!canAccessServerId(numericId) || !hasServerCapability('view')) {
+      ui.log('You do not have permission to access this server.');
+      return;
+    }
     const previous = state.currentServerId;
     if (previous === numericId) {
       showWorkspaceForServer(numericId);
@@ -1490,7 +1696,7 @@
       return;
     }
     if (previous != null && previous !== numericId) {
-      if (socket?.connected) {
+      if (socket?.connected && hasServerCapability('console')) {
         try { socket.emit('leave-server', previous); }
         catch { /* ignore */ }
       }
@@ -1502,9 +1708,10 @@
     highlightSelectedServer();
     ui.clearConsole();
     const name = entry?.data?.name || `Server #${numericId}`;
-    ui.log(`Connecting to ${name}...`);
+    const consoleAccess = hasServerCapability('console');
+    ui.log(`${consoleAccess ? 'Connecting to' : 'Opening'} ${name}...`);
     const sock = ensureSocket();
-    if (sock && sock.connected) {
+    if (sock && sock.connected && consoleAccess) {
       sock.emit('join-server', numericId);
     }
     showWorkspaceForServer(numericId);
@@ -1554,10 +1761,10 @@
       userBox.innerHTML = '';
       if (profileUsername) profileUsername.textContent = user?.username || '—';
       if (profileRole) {
-        const roleLabel = user?.role ? user.role.charAt(0).toUpperCase() + user.role.slice(1) : '—';
-        profileRole.textContent = roleLabel;
+        profileRole.textContent = formatUserRole(user);
       }
       if (!user) {
+        applyPermissionGates();
         return;
       }
       const header = document.createElement('div');
@@ -1565,17 +1772,17 @@
       const strong = document.createElement('strong');
       strong.textContent = user.username;
       header.appendChild(strong);
-      if (user.role === 'admin') {
+      if (user.role) {
         const badge = document.createElement('span');
         badge.className = 'badge';
-        badge.textContent = 'Admin';
+        badge.textContent = formatUserRole(user);
         header.appendChild(badge);
       }
       userBox.appendChild(header);
 
       const descriptor = document.createElement('span');
       descriptor.className = 'menu-description';
-      descriptor.textContent = user.role === 'admin' ? 'Administrator access' : 'Standard access';
+      descriptor.textContent = `Role: ${formatUserRole(user)}`;
       userBox.appendChild(descriptor);
 
       const actions = document.createElement('div');
@@ -1602,6 +1809,7 @@
       actions.appendChild(accountBtn);
       actions.appendChild(logoutBtn);
       userBox.appendChild(actions);
+      applyPermissionGates();
     }
   };
 
@@ -1676,6 +1884,11 @@
     state.serverItems.clear();
     state.settings = {};
     state.activePanel = 'dashboard';
+    state.roles = [];
+    state.roleTemplates = { serverCapabilities: [], globalPermissions: [] };
+    activeRoleEditKey = null;
+    updateRoleOptions();
+    updateRoleManagerVisibility(false);
     serversEl.innerHTML = '';
     ui.clearConsole();
     ui.setUser(null);
@@ -1750,7 +1963,7 @@
   }
 
   async function loadUsers() {
-    if (!state.currentUser || state.currentUser.role !== 'admin') return;
+    if (!hasGlobalPermission('manageUsers')) return;
     hideNotice(userFeedback);
     try {
       const list = await api('/users');
@@ -1769,7 +1982,7 @@
         primary.appendChild(name);
         const meta = document.createElement('span');
         meta.className = 'user-item-meta';
-        meta.textContent = `Role: ${formatUserRole(user.role)}`;
+        meta.textContent = `Role: ${formatUserRole(user)}`;
         primary.appendChild(meta);
         button.appendChild(primary);
 
@@ -1817,14 +2030,300 @@
     }
   }
 
+  function formatAllowedServersList(list) {
+    if (!Array.isArray(list) || list.length === 0) return '';
+    if (list.includes('*')) return '*';
+    return list.map((entry) => String(entry)).join(', ');
+  }
+
+  function parseAllowedServersInput(text) {
+    const value = (text || '').trim();
+    if (!value) return [];
+    if (value === '*') return ['*'];
+    return value.split(',').map((part) => part.trim()).filter(Boolean);
+  }
+
+  function renderRoleEditorFields() {
+    if (roleCapabilitiesFieldset) {
+      roleCapabilitiesFieldset.innerHTML = '';
+      const caps = state.roleTemplates?.serverCapabilities || [];
+      if (!caps.length) {
+        const note = document.createElement('p');
+        note.className = 'muted small';
+        note.textContent = 'No server capabilities available.';
+        roleCapabilitiesFieldset.appendChild(note);
+      } else {
+        caps.forEach((cap) => {
+          const label = document.createElement('label');
+          label.className = 'inline';
+          const input = document.createElement('input');
+          input.type = 'checkbox';
+          input.dataset.roleCapability = cap;
+          input.addEventListener('change', () => hideNotice(roleFeedback));
+          label.appendChild(input);
+          label.append(` ${cap.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase())}`);
+          roleCapabilitiesFieldset.appendChild(label);
+        });
+      }
+    }
+    if (roleGlobalFieldset) {
+      roleGlobalFieldset.innerHTML = '';
+      const perms = state.roleTemplates?.globalPermissions || [];
+      if (!perms.length) {
+        const note = document.createElement('p');
+        note.className = 'muted small';
+        note.textContent = 'No global permissions available.';
+        roleGlobalFieldset.appendChild(note);
+      } else {
+        perms.forEach((perm) => {
+          const label = document.createElement('label');
+          label.className = 'inline';
+          const input = document.createElement('input');
+          input.type = 'checkbox';
+          input.dataset.roleGlobal = perm;
+          input.addEventListener('change', () => hideNotice(roleFeedback));
+          label.appendChild(input);
+          label.append(` ${perm.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase())}`);
+          roleGlobalFieldset.appendChild(label);
+        });
+      }
+    }
+  }
+
+  function populateRoleSelectOptions(select, roles = [], preserve = true) {
+    if (!select) return;
+    const previous = preserve ? select.value : '';
+    select.innerHTML = '';
+    roles.forEach((role) => {
+      const option = document.createElement('option');
+      option.value = role.key;
+      option.textContent = role.name || role.key;
+      select.appendChild(option);
+    });
+    if (roles.length === 0) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No roles available';
+      select.appendChild(option);
+      select.disabled = true;
+      select.value = '';
+      return;
+    }
+    select.disabled = false;
+    if (previous && roles.some((role) => role.key === previous)) {
+      select.value = previous;
+    } else {
+      select.value = roles[0].key;
+    }
+  }
+
+  function updateRoleOptions() {
+    const roles = state.roles || [];
+    populateRoleSelectOptions(newUserRole, roles);
+    populateRoleSelectOptions(userDetailsRoleSelect, roles);
+    populateRoleSelectOptions(roleSelect, roles, false);
+  }
+
+  function applyRoleToEditor(role) {
+    if (!roleEditor) return;
+    hideNotice(roleFeedback);
+    if (!role) {
+      roleEditor.classList.add('hidden');
+      roleEditor.setAttribute('aria-hidden', 'true');
+      return;
+    }
+    roleEditor.classList.remove('hidden');
+    roleEditor.setAttribute('aria-hidden', 'false');
+    if (roleSelect && roleSelect.value !== role.key) roleSelect.value = role.key;
+    if (roleNameInput) roleNameInput.value = role.name || '';
+    if (roleDescriptionInput) roleDescriptionInput.value = role.description || '';
+    if (roleServersInput) roleServersInput.value = formatAllowedServersList(role.permissions?.servers?.allowed);
+    if (roleCapabilitiesFieldset) {
+      const caps = role.permissions?.servers?.capabilities || {};
+      roleCapabilitiesFieldset.querySelectorAll('input[data-role-capability]').forEach((input) => {
+        const cap = input.dataset.roleCapability;
+        input.checked = !!caps?.[cap];
+      });
+    }
+    if (roleGlobalFieldset) {
+      const globals = role.permissions?.global || {};
+      roleGlobalFieldset.querySelectorAll('input[data-role-global]').forEach((input) => {
+        const perm = input.dataset.roleGlobal;
+        input.checked = !!globals?.[perm];
+      });
+    }
+  }
+
+  function openRoleEditor(key) {
+    activeRoleEditKey = key || null;
+    const role = findRoleDefinition(activeRoleEditKey);
+    applyRoleToEditor(role);
+  }
+
+  function collectRoleCapabilities() {
+    const result = {};
+    if (!roleCapabilitiesFieldset) return result;
+    roleCapabilitiesFieldset.querySelectorAll('input[data-role-capability]').forEach((input) => {
+      const cap = input.dataset.roleCapability;
+      if (!cap) return;
+      result[cap] = !!input.checked;
+    });
+    return result;
+  }
+
+  function collectRoleGlobalPermissions() {
+    const result = {};
+    if (!roleGlobalFieldset) return result;
+    roleGlobalFieldset.querySelectorAll('input[data-role-global]').forEach((input) => {
+      const perm = input.dataset.roleGlobal;
+      if (!perm) return;
+      result[perm] = !!input.checked;
+    });
+    return result;
+  }
+
+  async function handleRoleCreate() {
+    if (!hasGlobalPermission('manageRoles')) return;
+    hideNotice(roleFeedback);
+    const keyValue = (newRoleKey?.value || '').trim().toLowerCase();
+    const nameValue = newRoleName?.value?.trim();
+    if (!keyValue || !nameValue) {
+      showNotice(roleFeedback, 'Provide both a key and name for the role.', 'error');
+      return;
+    }
+    try {
+      await api('/roles', { key: keyValue, name: nameValue }, 'POST');
+      if (newRoleKey) newRoleKey.value = '';
+      if (newRoleName) newRoleName.value = '';
+      showNotice(roleFeedback, 'Role created. Configure its permissions below.', 'success');
+      await loadRoles();
+      openRoleEditor(keyValue);
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else showNotice(roleFeedback, describeError(err), 'error');
+    }
+  }
+
+  async function handleRoleSave() {
+    if (!hasGlobalPermission('manageRoles') || !activeRoleEditKey) return;
+    hideNotice(roleFeedback);
+    const nameValue = roleNameInput?.value?.trim();
+    if (!nameValue) {
+      showNotice(roleFeedback, 'Role name cannot be empty.', 'error');
+      return;
+    }
+    const payload = {
+      name: nameValue,
+      description: roleDescriptionInput?.value?.trim() || null,
+      allowedServers: parseAllowedServersInput(roleServersInput?.value || ''),
+      capabilities: collectRoleCapabilities(),
+      global: collectRoleGlobalPermissions()
+    };
+    try {
+      await api(`/roles/${activeRoleEditKey}`, payload, 'PATCH');
+      showNotice(roleFeedback, 'Role updated.', 'success');
+      await loadRoles();
+      openRoleEditor(activeRoleEditKey);
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else showNotice(roleFeedback, describeError(err), 'error');
+    }
+  }
+
+  async function handleRoleDelete() {
+    if (!hasGlobalPermission('manageRoles') || !activeRoleEditKey) return;
+    hideNotice(roleFeedback);
+    const role = findRoleDefinition(activeRoleEditKey);
+    if (!role) return;
+    if (!confirm(`Delete the role "${role.name || role.key}"? This cannot be undone.`)) return;
+    try {
+      await api(`/roles/${activeRoleEditKey}`, null, 'DELETE');
+      showNotice(roleFeedback, 'Role removed.', 'success');
+      activeRoleEditKey = null;
+      await loadRoles();
+      if (state.roles.length) {
+        openRoleEditor(state.roles[0].key);
+      } else {
+        applyRoleToEditor(null);
+      }
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else showNotice(roleFeedback, describeError(err), 'error');
+    }
+  }
+
+  async function loadRoles() {
+    if (!state.TOKEN) return;
+    if (!hasGlobalPermission('manageRoles') && !hasGlobalPermission('manageUsers')) {
+      state.roles = [];
+      state.roleTemplates = { serverCapabilities: [], globalPermissions: [] };
+      activeRoleEditKey = null;
+      updateRoleOptions();
+      updateRoleManagerVisibility(false);
+      applyPermissionGates();
+      return;
+    }
+    try {
+      const data = await api('/roles');
+      state.roles = Array.isArray(data?.roles) ? data.roles : [];
+      state.roleTemplates = data?.templates || { serverCapabilities: [], globalPermissions: [] };
+      renderRoleEditorFields();
+      updateRoleOptions();
+      if (!state.roles.length) {
+        activeRoleEditKey = null;
+        applyRoleToEditor(null);
+      } else if (hasGlobalPermission('manageRoles')) {
+        const target = activeRoleEditKey && state.roles.some((role) => role.key === activeRoleEditKey)
+          ? activeRoleEditKey
+          : state.roles[0]?.key;
+        if (target) openRoleEditor(target);
+      } else {
+        activeRoleEditKey = null;
+        applyRoleToEditor(null);
+      }
+      applyPermissionGates();
+    } catch (err) {
+      if (errorCode(err) === 'unauthorized') handleUnauthorized();
+      else ui.log('Failed to load roles: ' + describeError(err));
+    }
+  }
+
+  function updateRoleManagerVisibility(canManageRoles) {
+    if (!roleManager) return;
+    const active = !!canManageRoles;
+    roleManager.classList.toggle('hidden', !active);
+    roleManager.setAttribute('aria-hidden', active ? 'false' : 'true');
+    if (rolesHeader) {
+      rolesHeader.classList.toggle('hidden', !active);
+      rolesHeader.setAttribute('aria-hidden', active ? 'false' : 'true');
+    }
+    if (!active) {
+      activeRoleEditKey = null;
+      applyRoleToEditor(null);
+    } else if (!activeRoleEditKey && state.roles.length) {
+      openRoleEditor(state.roles[0].key);
+    }
+  }
+
   function toggleUserCard() {
-    if (state.currentUser?.role === 'admin') {
+    const canUsers = hasGlobalPermission('manageUsers');
+    const canRoles = hasGlobalPermission('manageRoles');
+    if (canUsers || canRoles) {
       userCard.classList.remove('hidden');
-      loadUsers();
+      if (canUsers) {
+        loadUsers();
+      } else {
+        userList.innerHTML = '';
+        closeUserDetails();
+      }
+      if (userCreateSection) userCreateSection.classList.toggle('hidden', !canUsers);
+      updateRoleManagerVisibility(canRoles);
     } else {
       userCard.classList.add('hidden');
       userList.innerHTML = '';
       closeUserDetails();
+      if (userCreateSection) userCreateSection.classList.add('hidden');
+      updateRoleManagerVisibility(false);
     }
   }
 
@@ -1867,9 +2366,16 @@
     }
     try {
       const me = await api('/me');
-      state.currentUser = me;
+      state.currentUser = {
+        id: me.id,
+        username: me.username,
+        role: me.role,
+        roleName: me.roleName || me.role,
+        permissions: me.permissions || {}
+      };
+      await loadRoles();
       await loadSettings();
-      ui.setUser(me);
+      ui.setUser(state.currentUser);
       ui.showApp();
       ensureSocket();
       await refreshServers();
@@ -1904,7 +2410,14 @@
       const data = await publicJson('/login', { method: 'POST', body: { username, password } });
       state.TOKEN = data.token;
       localStorage.setItem('token', state.TOKEN);
-      state.currentUser = { id: data.id, username: data.username, role: data.role };
+      state.currentUser = {
+        id: data.id,
+        username: data.username,
+        role: data.role,
+        roleName: data.roleName || data.role,
+        permissions: data.permissions || {}
+      };
+      await loadRoles();
       await loadSettings();
       ui.setUser(state.currentUser);
       ui.showApp();
@@ -1957,6 +2470,10 @@
   }
 
   async function addServer() {
+    if (!hasGlobalPermission('manageServers')) {
+      ui.log('You do not have permission to manage servers.');
+      return;
+    }
     const name = svName?.value.trim();
     const host = svHost?.value.trim();
     const port = parseInt(svPort?.value || '0', 10);
@@ -1987,6 +2504,8 @@
     const cmd = (command || '').toString().trim();
     if (!cmd) throw new Error('missing_command');
     if (state.currentServerId == null) throw new Error('no_server_selected');
+    if (!hasServerCapability('commands')) throw new Error('forbidden');
+    if (!canAccessServerId(state.currentServerId)) throw new Error('forbidden');
     return await api(`/rcon/${state.currentServerId}`, { cmd }, 'POST');
   }
 
@@ -2005,6 +2524,10 @@
     } catch (err) {
       if (errorCode(err) === 'no_server_selected') {
         ui.log('Select a server before sending commands.');
+        return;
+      }
+      if (errorCode(err) === 'forbidden') {
+        ui.log(describeError(err));
         return;
       }
       if (errorCode(err) === 'unauthorized') handleUnauthorized();
@@ -2059,7 +2582,7 @@
     addServerPrompt?.addEventListener('click', () => toggleAddServerCardVisibility());
     btnBackToDashboard?.addEventListener('click', () => hideWorkspace('back'));
     btnCreateUser?.addEventListener('click', async () => {
-      if (state.currentUser?.role !== 'admin') return;
+      if (!hasGlobalPermission('manageUsers')) return;
       hideNotice(userFeedback);
       const username = newUserName?.value.trim();
       const password = newUserPassword?.value || '';
@@ -2084,6 +2607,29 @@
         else showNotice(userFeedback, describeError(err), 'error');
       }
     });
+    userDetailsRoleSelect?.addEventListener('change', () => hideNotice(userDetailsRoleStatus));
+    roleSelect?.addEventListener('change', () => {
+      if (!hasGlobalPermission('manageRoles')) return;
+      hideNotice(roleFeedback);
+      openRoleEditor(roleSelect.value);
+    });
+    btnCreateRole?.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      handleRoleCreate();
+    });
+    btnSaveRole?.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      handleRoleSave();
+    });
+    btnDeleteRole?.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      handleRoleDelete();
+    });
+    newRoleKey?.addEventListener('input', () => hideNotice(roleFeedback));
+    newRoleName?.addEventListener('input', () => hideNotice(roleFeedback));
+    roleNameInput?.addEventListener('input', () => hideNotice(roleFeedback));
+    roleDescriptionInput?.addEventListener('input', () => hideNotice(roleFeedback));
+    roleServersInput?.addEventListener('input', () => hideNotice(roleFeedback));
     setAddServerPromptState(addServerCard && !addServerCard.classList.contains('hidden'));
     document.addEventListener('click', (ev) => {
       const target = ev.target instanceof Node ? ev.target : null;
@@ -2099,6 +2645,7 @@
   async function init() {
     setApiBase(detectDefaultApiBase());
     bindEvents();
+    applyPermissionGates();
     if (state.TOKEN) {
       await attemptSessionResume();
     } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,17 +113,14 @@
             </div>
           </div>
           <div class="team-card-body">
-            <div class="user-create">
+            <div class="user-create" id="userCreateSection">
               <h4>Invite a teammate</h4>
               <div class="grid2 stack-sm">
                 <input id="newUserName" placeholder="Username">
                 <input id="newUserPassword" type="password" placeholder="Temporary password">
               </div>
               <label>Role
-                <select id="newUserRole">
-                  <option value="user">User</option>
-                  <option value="admin">Admin</option>
-                </select>
+                <select id="newUserRole"></select>
               </label>
               <div class="row">
                 <button id="btnCreateUser" class="accent">Create user</button>
@@ -132,6 +129,37 @@
             </div>
             <h4>Existing users</h4>
             <ul id="userList" class="users"></ul>
+            <h4 class="roles-header" id="rolesHeader">Roles</h4>
+            <div id="roleManager" class="roles-manager">
+              <div class="role-create">
+                <div class="grid2 stack-sm">
+                  <input id="newRoleKey" placeholder="New role key">
+                  <input id="newRoleName" placeholder="Name">
+                </div>
+                <div class="row">
+                  <button id="btnCreateRole" class="ghost">Create role</button>
+                </div>
+              </div>
+              <div id="roleEditor" class="role-editor hidden" aria-hidden="true">
+                <label>Role
+                  <select id="roleSelect"></select>
+                </label>
+                <input id="roleName" placeholder="Display name">
+                <input id="roleDescription" placeholder="Description (optional)">
+                <input id="roleServers" placeholder="Allowed server IDs (* for all)">
+                <fieldset id="roleCapabilities" class="role-fieldset">
+                  <legend>Server capabilities</legend>
+                </fieldset>
+                <fieldset id="roleGlobalPermissions" class="role-fieldset">
+                  <legend>Global permissions</legend>
+                </fieldset>
+                <div class="row space-between">
+                  <button id="btnSaveRole" class="accent">Save changes</button>
+                  <button id="btnDeleteRole" class="ghost danger">Delete role</button>
+                </div>
+                <p id="roleFeedback" class="notice hidden"></p>
+              </div>
+            </div>
           </div>
         </aside>
       </main>
@@ -174,7 +202,13 @@
             This is your account. Role changes and removal are disabled here.
           </p>
           <div class="user-details-actions">
-            <button id="userDetailsToggleRole" type="button" class="ghost">Promote to admin</button>
+            <div class="user-role-editor">
+              <label class="inline">Role
+                <select id="userDetailsRoleSelect"></select>
+              </label>
+              <button id="userDetailsSaveRole" type="button" class="ghost">Update role</button>
+            </div>
+            <p id="userDetailsRoleStatus" class="notice small hidden"></p>
             <button id="userDetailsResetPassword" type="button" class="ghost">Reset password</button>
             <button id="userDetailsDelete" type="button" class="ghost danger">Remove user</button>
           </div>
@@ -192,15 +226,15 @@
         </div>
 
         <nav id="workspaceMenu" class="workspace-menu" aria-label="Server sections">
-          <button type="button" class="menu-tab active" data-view="players" aria-pressed="true">Players</button>
-          <button type="button" class="menu-tab" data-view="map" aria-pressed="false">Map</button>
-          <button type="button" class="menu-tab" data-view="settings" aria-pressed="false">Settings</button>
-          <button type="button" class="menu-tab" data-view="console" aria-pressed="false">Console</button>
-          <button type="button" class="menu-tab" data-view="dashboard" aria-pressed="false">Dashboard</button>
+          <button type="button" class="menu-tab active" data-view="players" data-capability="players" aria-pressed="true">Players</button>
+          <button type="button" class="menu-tab" data-view="map" data-capability="liveMap" aria-pressed="false">Map</button>
+          <button type="button" class="menu-tab" data-view="settings" data-capability="manage" aria-pressed="false">Settings</button>
+          <button type="button" class="menu-tab" data-view="console" data-capability="console" aria-pressed="false">Console</button>
+          <button type="button" class="menu-tab" data-view="dashboard" data-capability="view" aria-pressed="false">Dashboard</button>
         </nav>
 
         <div class="workspace-views">
-          <section id="workspaceViewPlayers" class="workspace-view active" data-view="players" aria-hidden="false">
+          <section id="workspaceViewPlayers" class="workspace-view active" data-view="players" data-capability="players" aria-hidden="false">
             <div class="card graph-card module-hidden" data-module-card="players-graph">
               <div class="card-header">
                 <div class="card-title-group">
@@ -232,7 +266,7 @@
             </div>
           </section>
 
-          <section id="workspaceViewMap" class="workspace-view" data-view="map" aria-hidden="true">
+          <section id="workspaceViewMap" class="workspace-view" data-view="map" data-capability="liveMap" aria-hidden="true">
             <div class="card map-card" data-module-card="live-map">
               <div class="card-header">
                 <div class="card-title-group">
@@ -244,7 +278,7 @@
             </div>
           </section>
 
-          <section id="workspaceViewSettings" class="workspace-view" data-view="settings" aria-hidden="true">
+          <section id="workspaceViewSettings" class="workspace-view" data-view="settings" data-capability="manage" aria-hidden="true">
             <div class="card settings-card">
               <div class="card-header">
                 <div class="card-title-group">
@@ -299,7 +333,7 @@
             </div>
           </section>
 
-          <section id="workspaceViewConsole" class="workspace-view" data-view="console" aria-hidden="true">
+          <section id="workspaceViewConsole" class="workspace-view" data-view="console" data-capability="console" aria-hidden="true">
             <div class="card console-card">
               <div class="card-header">
                 <h3>Console</h3>
@@ -316,7 +350,7 @@
             </div>
           </section>
 
-          <section id="workspaceViewDashboard" class="workspace-view" data-view="dashboard" aria-hidden="true">
+          <section id="workspaceViewDashboard" class="workspace-view" data-view="dashboard" data-capability="view" aria-hidden="true">
             <div class="workspace-summary">
               <div class="summary-card">
                 <span class="summary-label">Players</span>


### PR DESCRIPTION
## Summary
- finalize the role management UI wiring so role editors, selectors, and notice handling react to permission changes
- ensure role options refresh across user creation/details forms and hide the manager when access is revoked
- guard client commands and module events behind the new permission helpers to match backend enforcement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d676510668833192c9bfec7ac76077