### PR TITLE
Adjust player module layout and enhance search hints

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -108,7 +108,7 @@ main.grid{
 .players-strip .live-player-row:hover{background:rgba(225,29,72,.12)}
 .players-strip .live-player-details{align-items:flex-start}
 
-.players-directory{padding:0}
+.players-directory{padding:0;max-width:1120px;margin-right:auto;width:100%}
 .players-directory .module-message{padding:24px; text-align:center}
 .player-directory{
   list-style:none;
@@ -159,7 +159,7 @@ main.grid{
 .player-list-body .live-player-row:hover{background:rgba(225,29,72,.08)}
 .card.list-card{margin-top:16px}
 .players-card{grid-column:1/-1;margin-top:18px}
-.players-card .card-body{padding:0}
+.players-card .card-body{padding:0;display:flex;justify-content:flex-start}
 .card-head{
   display:flex; align-items:center; justify-content:space-between;
   padding:12px 14px; border-bottom:1px solid var(--border)

--- a/frontend/assets/modules/live-players.js
+++ b/frontend/assets/modules/live-players.js
@@ -114,9 +114,9 @@
         searchWrap.className = 'module-search';
         searchInput = document.createElement('input');
         searchInput.type = 'search';
-        searchInput.placeholder = 'Search players';
+        searchInput.placeholder = 'Search players, Steam ID or IP';
         searchInput.autocomplete = 'off';
-        searchInput.setAttribute('aria-label', 'Search connected players');
+        searchInput.setAttribute('aria-label', 'Search connected players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);
       }

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -27,9 +27,9 @@
         searchWrap.className = 'module-search';
         searchInput = document.createElement('input');
         searchInput.type = 'search';
-        searchInput.placeholder = 'Search players';
+        searchInput.placeholder = 'Search players, Steam ID or IP';
         searchInput.autocomplete = 'off';
-        searchInput.setAttribute('aria-label', 'Search players');
+        searchInput.setAttribute('aria-label', 'Search players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);
       }

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1344,6 +1344,15 @@ button.menu-tab.active {
   display: flex;
   flex-direction: column;
   gap: 18px;
+  max-width: 1120px;
+  margin-right: auto;
+  width: 100%;
+  align-self: flex-start;
+}
+
+.players-card .card-body {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .players-graph-card .card-body,
@@ -1506,7 +1515,9 @@ button.menu-tab.active {
 .live-players-list {
   display: grid;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 360px));
+  justify-content: flex-start;
+  align-content: start;
 }
 
 .live-player-row {
@@ -1707,6 +1718,9 @@ button.menu-tab.active {
   padding: 0;
   border: none;
   background: none;
+  max-width: 1120px;
+  margin-right: auto;
+  width: 100%;
 }
 
 .player-directory {


### PR DESCRIPTION
## Summary
- limit the live players and directory modules to a compact max width and align them to the top-left
- tighten the live player grid so individual player cards keep a consistent card width
- clarify the player search inputs accept Steam IDs and IP addresses across both modules

## Testing
- Manually opened the frontend in a browser

------
https://chatgpt.com/codex/tasks/task_e_68d704fc84688331a979d77aa044b177