### PR TITLE
Improve role editor clarity and layout

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -207,8 +207,10 @@ label.inline input[type="checkbox"],
   border-radius: 5px;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(12, 2, 5, 0.75);
-  display: grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
   cursor: pointer;
   transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
 }
@@ -216,12 +218,13 @@ label.inline input[type="checkbox"],
 label.inline input[type="checkbox"]::after,
 .role-checkbox input[type="checkbox"]::after {
   content: '';
-  width: 9px;
-  height: 5px;
-  border: 2px solid transparent;
-  border-top: 0;
-  border-left: 0;
+  width: 6px;
+  height: 10px;
+  border: solid #1f0206;
+  border-width: 0 2px 2px 0;
   transform: rotate(45deg) scale(0);
+  transform-origin: center;
+  position: absolute;
   transition: transform 0.12s ease;
 }
 
@@ -234,7 +237,6 @@ label.inline input[type="checkbox"]:checked,
 
 label.inline input[type="checkbox"]:checked::after,
 .role-checkbox input[type="checkbox"]:checked::after {
-  border-color: #1f0206;
   transform: rotate(45deg) scale(1);
 }
 
@@ -908,9 +910,9 @@ label.inline input[type="checkbox"]:focus-visible,
 .role-access-head p { margin: 0; }
 
 .role-checkbox-list {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .role-checkbox {
@@ -924,6 +926,7 @@ label.inline input[type="checkbox"]:focus-visible,
   color: var(--text);
   cursor: pointer;
   transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+  width: 100%;
 }
 
 .role-checkbox:hover {
@@ -931,7 +934,7 @@ label.inline input[type="checkbox"]:focus-visible,
   background: rgba(255, 255, 255, 0.05);
 }
 
-.role-checkbox input[type="checkbox"] { margin-top: 2px; }
+.role-checkbox input[type="checkbox"] { margin-top: 0; }
 
 .role-checkbox input[type="checkbox"]:disabled {
   cursor: not-allowed;
@@ -970,11 +973,6 @@ label.inline input[type="checkbox"]:focus-visible,
 .role-checkbox-empty {
   margin: 0;
   padding: 6px 0 4px;
-  grid-column: 1 / -1;
-}
-
-@media (max-width: 640px) {
-  .role-checkbox-list { grid-template-columns: 1fr; }
 }
 
 .users {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -160,11 +160,17 @@
                 </div>
               </div>
               <div id="roleEditor" class="role-editor hidden" aria-hidden="true">
-                <label>Role
+                <label for="roleSelect">Role
                   <select id="roleSelect"></select>
                 </label>
-                <input id="roleName" placeholder="Display name">
-                <input id="roleDescription" placeholder="Description (optional)">
+                <label for="roleName">Role name
+                  <input id="roleName" placeholder="Display name">
+                  <span class="muted small">Shown wherever the role is referenced in the panel.</span>
+                </label>
+                <label for="roleDescription">Role description
+                  <input id="roleDescription" placeholder="Description (optional)">
+                  <span class="muted small">Give teammates context about what this role is for.</span>
+                </label>
                 <div class="role-access">
                   <div class="role-access-head">
                     <h5>Server access</h5>
@@ -172,11 +178,20 @@
                   </div>
                   <div id="roleServersList" class="role-checkbox-list" role="group" aria-label="Allowed servers"></div>
                 </div>
-                <fieldset id="roleCapabilities" class="role-fieldset">
+                <fieldset class="role-fieldset">
                   <legend>Server capabilities</legend>
+                  <p class="muted small">Decide which actions this role can take on the servers they can reach.</p>
+                  <div id="roleCapabilities" class="role-checkbox-list" role="group" aria-label="Server capabilities"></div>
                 </fieldset>
-                <fieldset id="roleGlobalPermissions" class="role-fieldset">
+                <fieldset class="role-fieldset">
                   <legend>Global permissions</legend>
+                  <p class="muted small">Grant access to panel-wide tools and management features.</p>
+                  <div
+                    id="roleGlobalPermissions"
+                    class="role-checkbox-list"
+                    role="group"
+                    aria-label="Global permissions"
+                  ></div>
                 </fieldset>
                 <div class="row space-between">
                   <button id="btnSaveRole" class="accent">Save changes</button>


### PR DESCRIPTION
## Summary
- add helper copy for role name and description inputs to guide admins
- restyle role capability and permission checkboxes and surface human-friendly descriptions
- adjust checkbox visuals for proper alignment and single-column layout in the role editor

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7057fe0dc833183de0ab6f98ee94b