### PR TITLE
Prevent editing own role and refine role manager

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1942,6 +1942,10 @@ app.post('/api/roles', auth, requireGlobalPermissionMiddleware('manageRoles'), a
 app.patch('/api/roles/:key', auth, requireGlobalPermissionMiddleware('manageRoles'), async (req, res) => {
   const key = normalizeRoleKey(req.params.key);
   if (!key) return res.status(400).json({ error: 'invalid_role_key' });
+  const activeRoleKey = normalizeRoleKey(req.authUser?.role);
+  if (activeRoleKey && activeRoleKey === key) {
+    return res.status(400).json({ error: 'cannot_edit_active_role' });
+  }
   const body = req.body || {};
   const updates = {};
   if (typeof body.name === 'string') {

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -123,6 +123,18 @@ button.ghost.danger:hover {
   color: #fee2e2;
 }
 
+button:disabled,
+input:disabled,
+select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  filter: saturate(0.6);
+}
+
+button:disabled {
+  pointer-events: none;
+}
+
 button.small { padding: 7px 14px; font-size: 0.9rem; border-radius: 999px; }
 
 .profile-actions {
@@ -258,6 +270,7 @@ label.inline input[type="checkbox"]:focus-visible,
 
 .notice.success { border-color: rgba(74, 222, 128, 0.35); color: var(--success); background: rgba(74, 222, 128, 0.12); }
 .notice.error { border-color: rgba(248, 113, 113, 0.35); color: var(--danger); background: rgba(248, 113, 113, 0.12); }
+.notice.warning { border-color: rgba(250, 204, 21, 0.35); color: var(--warning); background: rgba(250, 204, 21, 0.12); }
 
 .row { display: flex; gap: 12px; align-items: center; margin-top: 16px; flex-wrap: wrap; }
 .row.quick-row { margin-bottom: 4px; }
@@ -889,6 +902,56 @@ label.inline input[type="checkbox"]:focus-visible,
 
 .team-section-head h4 { font-size: 1.15rem; }
 .team-section-head p { margin: 0; }
+
+.roles-manager {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .roles-manager {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    align-items: flex-start;
+  }
+}
+
+.role-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(244, 63, 94, 0.08);
+}
+
+.role-section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.role-section-head h5 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+.role-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.role-editor.role-editor-locked {
+  opacity: 0.9;
+}
+
+#roleLockedNotice {
+  margin-top: 0;
+}
 
 .role-access {
   display: flex;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -150,55 +150,69 @@
                   <p id="rolesDescription" class="muted small">Define reusable access levels for your team.</p>
                 </div>
                 <div id="roleManager" class="roles-manager">
-              <div class="role-create">
-                <div class="grid2 stack-sm">
-                  <input id="newRoleKey" placeholder="New role key">
-                  <input id="newRoleName" placeholder="Name">
-                </div>
-                <div class="row">
-                  <button id="btnCreateRole" class="ghost">Create role</button>
-                </div>
-              </div>
-              <div id="roleEditor" class="role-editor hidden" aria-hidden="true">
-                <label for="roleSelect">Role
-                  <select id="roleSelect"></select>
-                </label>
-                <label for="roleName">Role name
-                  <input id="roleName" placeholder="Display name">
-                  <span class="muted small">Shown wherever the role is referenced in the panel.</span>
-                </label>
-                <label for="roleDescription">Role description
-                  <input id="roleDescription" placeholder="Description (optional)">
-                  <span class="muted small">Give teammates context about what this role is for.</span>
-                </label>
-                <div class="role-access">
-                  <div class="role-access-head">
-                    <h5>Server access</h5>
-                    <p class="muted small">Choose which servers this role can access.</p>
-                  </div>
-                  <div id="roleServersList" class="role-checkbox-list" role="group" aria-label="Allowed servers"></div>
-                </div>
-                <fieldset class="role-fieldset">
-                  <legend>Server capabilities</legend>
-                  <p class="muted small">Decide which actions this role can take on the servers they can reach.</p>
-                  <div id="roleCapabilities" class="role-checkbox-list" role="group" aria-label="Server capabilities"></div>
-                </fieldset>
-                <fieldset class="role-fieldset">
-                  <legend>Global permissions</legend>
-                  <p class="muted small">Grant access to panel-wide tools and management features.</p>
-                  <div
-                    id="roleGlobalPermissions"
-                    class="role-checkbox-list"
-                    role="group"
-                    aria-label="Global permissions"
-                  ></div>
-                </fieldset>
-                <div class="row space-between">
-                  <button id="btnSaveRole" class="accent">Save changes</button>
-                  <button id="btnDeleteRole" class="ghost danger">Delete role</button>
-                </div>
-                <p id="roleFeedback" class="notice hidden"></p>
-              </div>
+                  <section id="roleCreateSection" class="role-section-card">
+                    <div class="role-section-head">
+                      <h5>Create a role</h5>
+                      <p class="muted small">Define the basics for a new role before assigning permissions.</p>
+                    </div>
+                    <div class="grid2 stack-sm">
+                      <input id="newRoleKey" placeholder="New role key">
+                      <input id="newRoleName" placeholder="Name">
+                    </div>
+                    <p class="muted small">Role keys use letters, numbers, dashes or underscores and cannot be changed later.</p>
+                    <div class="row">
+                      <button id="btnCreateRole" class="ghost">Create role</button>
+                    </div>
+                  </section>
+                  <section id="roleEditSection" class="role-section-card">
+                    <div class="role-section-head">
+                      <h5>Edit a role</h5>
+                      <p id="roleEditorEmpty" class="muted small hidden">Select a role to review and adjust its settings.</p>
+                    </div>
+                    <div id="roleEditor" class="role-editor hidden" aria-hidden="true">
+                      <p id="roleLockedNotice" class="notice warning small hidden">
+                        You cannot edit a role that is currently assigned to you. Switch to another role to make changes.
+                      </p>
+                      <label for="roleSelect">Role
+                        <select id="roleSelect"></select>
+                      </label>
+                      <label for="roleName">Role name
+                        <input id="roleName" placeholder="Display name">
+                        <span class="muted small">Shown wherever the role is referenced in the panel.</span>
+                      </label>
+                      <label for="roleDescription">Role description
+                        <input id="roleDescription" placeholder="Description (optional)">
+                        <span class="muted small">Give teammates context about what this role is for.</span>
+                      </label>
+                      <div class="role-access">
+                        <div class="role-access-head">
+                          <h5>Server access</h5>
+                          <p class="muted small">Choose which servers this role can access.</p>
+                        </div>
+                        <div id="roleServersList" class="role-checkbox-list" role="group" aria-label="Allowed servers"></div>
+                      </div>
+                      <fieldset class="role-fieldset">
+                        <legend>Server capabilities</legend>
+                        <p class="muted small">Decide which actions this role can take on the servers they can reach.</p>
+                        <div id="roleCapabilities" class="role-checkbox-list" role="group" aria-label="Server capabilities"></div>
+                      </fieldset>
+                      <fieldset class="role-fieldset">
+                        <legend>Global permissions</legend>
+                        <p class="muted small">Grant access to panel-wide tools and management features.</p>
+                        <div
+                          id="roleGlobalPermissions"
+                          class="role-checkbox-list"
+                          role="group"
+                          aria-label="Global permissions"
+                        ></div>
+                      </fieldset>
+                      <div class="row space-between">
+                        <button id="btnSaveRole" class="accent">Save changes</button>
+                        <button id="btnDeleteRole" class="ghost danger">Delete role</button>
+                      </div>
+                      <p id="roleFeedback" class="notice hidden"></p>
+                    </div>
+                  </section>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
## Summary
- split the role manager into dedicated create and edit sections with improved layout guidance and locked-role messaging
- disable client-side role editing when the active user selects their own role and surface a matching API error message to avoid accidental lockouts
- guard the role update endpoint against modifying the caller's current role so permissions cannot be stripped while signed in

## Testing
- node --check frontend/assets/app.js
- node --check backend/src/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d708a3c084833193ffc2b86edf8130