### PR TITLE
Update license to restrict commercial redistribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,26 @@
-MIT License
+Rust Control Panel Personal Use License
 Copyright (c) 2025
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to do so, subject to the
-following conditions:
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+
+Permission is hereby granted to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to use, copy, modify, and
+share the Software for personal, educational, or internal business purposes,
+subject to the following conditions:
+
+1. Non-Commercial Use Only. You may not sell, resell, rent, lease, license,
+sublicense, or otherwise commercialize the Software or any derivative work.
+2. No Rebranded Sales. You may not rebrand, white-label, or present the Software
+(or any derivative work) as your own product for the purpose of sale,
+distribution for a fee, or commercial advantage.
+3. Preservation of Notices. You must retain this license text, copyright
+notice, and any attribution notices in all copies or substantial portions of the
+Software and its derivatives.
+4. No Warranty. The Software is provided "as is", without warranty of any kind,
+express or implied, including but not limited to the warranties of
+merchantability, fitness for a particular purpose, and noninfringement. In no
+event shall the authors or copyright holders be liable for any claim, damages,
+or other liability, whether in an action of contract, tort, or otherwise,
+arising from, out of, or in connection with the Software or the use or other
+dealings in the Software.
+
+Any use of the Software in violation of these conditions terminates the rights
+granted by this license.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ sudo bash scripts/install-linux.sh
 
 Need a tour of the codebase? Check out [`FILES.md`](FILES.md) for a high-level description of each file and directory.
 
+## License
+
+This project is released under the **Rust Control Panel Personal Use License**, which allows you to use, modify, and share the software for personal, educational, or internal business purposes. Commercial redistribution, resale, or rebranding for sale is not permitted. See [`LICENSE`](LICENSE) for the full terms.
+
 ## Uninstall
 ```bash
 # Safe uninstall (keeps data in /opt/rustadmin)


### PR DESCRIPTION
## Summary
- replace the MIT license with a custom personal-use license that forbids resale or rebranded commercial distribution
- document the new licensing terms in the README for quick reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70b49ffc48331870e2ee6361bf511