### PR TITLE
Switch Discord bot presence to watching

### DIFF
--- a/backend/src/discord-bot-service.js
+++ b/backend/src/discord-bot-service.js
@@ -577,7 +577,7 @@ async function updateBot(state, integration) {
     try {
       await state.client.user.setPresence({
         status: presence.status,
-        activities: [{ name: presence.activity, type: ActivityType.Playing }]
+        activities: [{ name: presence.activity, type: ActivityType.Watching }]
       });
       state.lastPresenceKey = presenceKey;
     } catch (err) {


### PR DESCRIPTION
## Summary
- update the Discord bot presence activity type to Watching so the status reads "Watching"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7118f528c8331a08ae7440823337a