### PR TITLE
Automate live map world detection with enhanced status feedback

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2384,14 +2384,9 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
 
     // derive a status + requirements summary for the frontend
     let status = 'ready';
-    const requirements = {};
     if (!mapPayload) {
       if (!info?.size || !info?.seed) {
-        status = 'awaiting_world_details';
-        requirements.world = {
-          sizeMissing: !info?.size,
-          seedMissing: !info?.seed
-        };
+        status = 'awaiting_server_info';
       } else {
         status = 'awaiting_imagery';
       }
@@ -2420,9 +2415,6 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       status,                    // <-- new
       fetchedAt: new Date().toISOString()
     };
-    if (Object.keys(requirements).length > 0) {
-      responsePayload.requirements = requirements;   // <-- new
-    }
 
     res.json(responsePayload);
   } catch (err) {
@@ -2573,8 +2565,15 @@ app.post('/api/servers/:id/map-image', auth, async (req, res) => {
     if (!server) return res.status(404).json({ error: 'not_found' });
     let record = await db.getServerMap(id);
     const info = getCachedServerInfo(id) || {};
+    const normalizedMapKey = typeof mapKey === 'string' && mapKey.trim() ? mapKey.trim() : null;
     const derivedKey = deriveMapKey(info) || null;
-    const targetKey = mapKey || record?.map_key || derivedKey || `custom-${id}`;
+    let targetKey;
+    if (record?.custom && record?.map_key) {
+      targetKey = record.map_key;
+    } else {
+      const baseKey = normalizedMapKey || derivedKey;
+      targetKey = baseKey ? `${baseKey}-server-${id}` : `server-${id}-custom`;
+    }
     if (record) await removeMapImage(record);
     if (record?.map_key && record.map_key !== targetKey) await removeGlobalMapMetadata(record.map_key);
     const filePath = serverMapImageFilePath(id, targetKey, decoded.extension);
@@ -2595,7 +2594,6 @@ app.post('/api/servers/:id/map-image', auth, async (req, res) => {
       image_path: filePath,
       custom: 1
     });
-    await saveGlobalMapMetadata(targetKey, data);
     record = await db.getServerMap(id);
     const map = mapRecordToPayload(id, record, data);
     res.json({ map, updatedAt: new Date().toISOString() });

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2417,6 +2417,72 @@ button.menu-tab.active {
   color: var(--muted);
 }
 
+.map-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  align-items: center;
+  justify-content: center;
+  text-align: left;
+}
+
+.map-status-spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid rgba(148, 163, 184, 0.28);
+  border-top-color: rgba(148, 163, 184, 0.9);
+  animation: map-status-spin 1s linear infinite;
+}
+
+.map-status-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.map-status-heading {
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+.map-status-note {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.map-status-details-label {
+  margin-top: 4px;
+}
+
+.map-status-details {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.map-status-details li {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.map-status-details li strong {
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+@keyframes map-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .map-config.hidden { display: none !important; }
 
 .map-config-form {


### PR DESCRIPTION
## Summary
- remove the manual world size/seed form from the live map and adjust messaging to rely on automatic server data
- report an `awaiting_server_info` status instead of requesting user input when world details are missing
- scope uploaded custom map imagery to the originating server so new uploads replace previous files without populating the global cache
- surface detected map details alongside a status-driven loading spinner while imagery is retrieved

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d711213ff483318a22d01906f54830