### PR TITLE
feat: add rich discord bot configuration commands

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -142,11 +142,13 @@ function createApi(pool, dialect) {
         guild_id VARCHAR(64) NULL,
         channel_id VARCHAR(64) NULL,
         status_message_id VARCHAR(64) NULL,
+        config_json TEXT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         CONSTRAINT fk_server_discord FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
       ) ENGINE=InnoDB;`);
       await ensureColumn('ALTER TABLE server_discord_integrations ADD COLUMN status_message_id VARCHAR(64) NULL');
+      await ensureColumn('ALTER TABLE server_discord_integrations ADD COLUMN config_json TEXT NULL');
     },
     async countUsers(){ const r = await exec('SELECT COUNT(*) c FROM users'); const row = Array.isArray(r)?r[0]:r; return row.c ?? row['COUNT(*)']; },
     async createUser(u){
@@ -463,16 +465,17 @@ function createApi(pool, dialect) {
       );
       return rows?.[0] ?? null;
     },
-    async saveServerDiscordIntegration(serverId,{ bot_token=null,guild_id=null,channel_id=null,status_message_id=null }){
+    async saveServerDiscordIntegration(serverId,{ bot_token=null,guild_id=null,channel_id=null,status_message_id=null,config_json=null }){
       await exec(`
-        INSERT INTO server_discord_integrations(server_id, bot_token, guild_id, channel_id, status_message_id)
-        VALUES(?,?,?,?,?)
+        INSERT INTO server_discord_integrations(server_id, bot_token, guild_id, channel_id, status_message_id, config_json)
+        VALUES(?,?,?,?,?,?)
         ON DUPLICATE KEY UPDATE
           bot_token=VALUES(bot_token),
           guild_id=VALUES(guild_id),
           channel_id=VALUES(channel_id),
-          status_message_id=VALUES(status_message_id)
-      `,[serverId, bot_token, guild_id, channel_id, status_message_id]);
+          status_message_id=VALUES(status_message_id),
+          config_json=VALUES(config_json)
+      `,[serverId, bot_token, guild_id, channel_id, status_message_id, config_json]);
     },
     async deleteServerDiscordIntegration(serverId){
       const result = await exec('DELETE FROM server_discord_integrations WHERE server_id=?',[serverId]);

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -118,6 +118,7 @@ function createApi(dbh, dialect) {
         guild_id TEXT,
         channel_id TEXT,
         status_message_id TEXT,
+        config_json TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now')),
         FOREIGN KEY(server_id) REFERENCES servers(id) ON DELETE CASCADE
@@ -126,6 +127,9 @@ function createApi(dbh, dialect) {
       const discordCols = await dbh.all("PRAGMA table_info('server_discord_integrations')");
       if (!discordCols.some((c) => c.name === 'status_message_id')) {
         await dbh.run("ALTER TABLE server_discord_integrations ADD COLUMN status_message_id TEXT");
+      }
+      if (!discordCols.some((c) => c.name === 'config_json')) {
+        await dbh.run("ALTER TABLE server_discord_integrations ADD COLUMN config_json TEXT");
       }
       const userCols = await dbh.all("PRAGMA table_info('users')");
       if (!userCols.some((c) => c.name === 'role')) {
@@ -510,10 +514,10 @@ function createApi(dbh, dialect) {
         [serverId]
       );
     },
-    async saveServerDiscordIntegration(serverId,{ bot_token=null,guild_id=null,channel_id=null,status_message_id=null }){
+    async saveServerDiscordIntegration(serverId,{ bot_token=null,guild_id=null,channel_id=null,status_message_id=null,config_json=null }){
       await dbh.run(
-        "INSERT INTO server_discord_integrations(server_id,bot_token,guild_id,channel_id,status_message_id,created_at,updated_at) VALUES(?,?,?,?,?,datetime('now'),datetime('now')) ON CONFLICT(server_id) DO UPDATE SET bot_token=excluded.bot_token, guild_id=excluded.guild_id, channel_id=excluded.channel_id, status_message_id=excluded.status_message_id, updated_at=excluded.updated_at",
-        [serverId, bot_token, guild_id, channel_id, status_message_id]
+        "INSERT INTO server_discord_integrations(server_id,bot_token,guild_id,channel_id,status_message_id,config_json,created_at,updated_at) VALUES(?,?,?,?,?,?,datetime('now'),datetime('now')) ON CONFLICT(server_id) DO UPDATE SET bot_token=excluded.bot_token, guild_id=excluded.guild_id, channel_id=excluded.channel_id, status_message_id=excluded.status_message_id, config_json=excluded.config_json, updated_at=excluded.updated_at",
+        [serverId, bot_token, guild_id, channel_id, status_message_id, config_json]
       );
     },
     async deleteServerDiscordIntegration(serverId){

--- a/backend/src/discord-config.js
+++ b/backend/src/discord-config.js
@@ -1,0 +1,191 @@
+export const STATUS_COLORS = Object.freeze({
+  online: 0x57f287,
+  offline: 0xed4245,
+  stale: 0xfee75c
+});
+
+const ALLOWED_PRESENCE_STATUSES = new Set(['online', 'idle', 'dnd', 'invisible']);
+
+export const DEFAULT_DISCORD_BOT_CONFIG = Object.freeze({
+  presenceTemplate: '{statusEmoji} {playerCount} on {serverName}',
+  presenceStatuses: Object.freeze({
+    online: 'online',
+    offline: 'dnd',
+    stale: 'idle',
+    waiting: 'idle'
+  }),
+  colors: Object.freeze({
+    ...STATUS_COLORS
+  }),
+  fields: Object.freeze({
+    joining: true,
+    queued: true,
+    sleepers: true,
+    fps: true,
+    lastUpdate: true
+  })
+});
+
+export const CONFIG_FIELD_CHOICES = [
+  { value: 'joining', name: 'Joining players' },
+  { value: 'queued', name: 'Queue length' },
+  { value: 'sleepers', name: 'Sleeping players' },
+  { value: 'fps', name: 'Server FPS' },
+  { value: 'lastUpdate', name: 'Last update timestamp' }
+];
+
+export const CONFIG_FIELD_LABELS = CONFIG_FIELD_CHOICES.reduce((map, choice) => {
+  map[choice.value] = choice.name;
+  return map;
+}, {});
+
+export const PRESENCE_TEMPLATE_TOKENS = Object.freeze([
+  'serverName',
+  'players',
+  'maxPlayers',
+  'playerCount',
+  'queued',
+  'sleepers',
+  'joining',
+  'fps',
+  'status',
+  'statusEmoji'
+]);
+
+const COLOR_HEX_REGEX = /^#?([0-9a-f]{6})$/i;
+
+export function parseColorString(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const clamped = Math.max(0, Math.min(0xffffff, Math.floor(value)));
+    return clamped;
+  }
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(COLOR_HEX_REGEX);
+  if (!match) return null;
+  return parseInt(match[1], 16);
+}
+
+export function formatColorHex(value) {
+  const numeric = typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.min(0xffffff, Math.floor(value)))
+    : 0;
+  return `#${numeric.toString(16).padStart(6, '0')}`;
+}
+
+function sanitizePresenceTemplate(template) {
+  if (typeof template !== 'string') return DEFAULT_DISCORD_BOT_CONFIG.presenceTemplate;
+  const trimmed = template.trim();
+  if (!trimmed) return DEFAULT_DISCORD_BOT_CONFIG.presenceTemplate;
+  return trimmed.slice(0, 190);
+}
+
+function normalizePresenceStatuses(statuses = {}) {
+  const source = typeof statuses === 'object' && statuses != null ? statuses : {};
+  const base = DEFAULT_DISCORD_BOT_CONFIG.presenceStatuses;
+  const out = {
+    online: ALLOWED_PRESENCE_STATUSES.has(source.online) ? source.online : base.online,
+    offline: ALLOWED_PRESENCE_STATUSES.has(source.offline) ? source.offline : base.offline,
+    stale: ALLOWED_PRESENCE_STATUSES.has(source.stale) ? source.stale : base.stale,
+    waiting: ALLOWED_PRESENCE_STATUSES.has(source.waiting) ? source.waiting : base.waiting
+  };
+  return out;
+}
+
+function normalizeFields(fields = {}) {
+  const source = typeof fields === 'object' && fields != null ? fields : {};
+  const base = DEFAULT_DISCORD_BOT_CONFIG.fields;
+  return {
+    joining: typeof source.joining === 'boolean' ? source.joining : base.joining,
+    queued: typeof source.queued === 'boolean' ? source.queued : base.queued,
+    sleepers: typeof source.sleepers === 'boolean' ? source.sleepers : base.sleepers,
+    fps: typeof source.fps === 'boolean' ? source.fps : base.fps,
+    lastUpdate: typeof source.lastUpdate === 'boolean' ? source.lastUpdate : base.lastUpdate
+  };
+}
+
+function normalizeColors(colors = {}) {
+  const source = typeof colors === 'object' && colors != null ? colors : {};
+  const base = DEFAULT_DISCORD_BOT_CONFIG.colors;
+  const normalize = (key) => {
+    const parsed = parseColorString(source[key]);
+    return parsed == null ? base[key] : parsed;
+  };
+  return {
+    online: normalize('online'),
+    offline: normalize('offline'),
+    stale: normalize('stale')
+  };
+}
+
+export function normaliseDiscordBotConfig(value = {}) {
+  if (value === DEFAULT_DISCORD_BOT_CONFIG) return cloneDiscordBotConfig(value);
+  const source = typeof value === 'object' && value != null ? value : {};
+  return {
+    presenceTemplate: sanitizePresenceTemplate(source.presenceTemplate ?? source.presence_template),
+    presenceStatuses: normalizePresenceStatuses(source.presenceStatuses ?? source.presence_statuses),
+    colors: normalizeColors(source.colors),
+    fields: normalizeFields(source.fields)
+  };
+}
+
+export function cloneDiscordBotConfig(config = DEFAULT_DISCORD_BOT_CONFIG) {
+  const normalised = normaliseDiscordBotConfig(config);
+  return {
+    presenceTemplate: normalised.presenceTemplate,
+    presenceStatuses: { ...normalised.presenceStatuses },
+    colors: { ...normalised.colors },
+    fields: { ...normalised.fields }
+  };
+}
+
+export function parseDiscordBotConfig(raw) {
+  if (raw == null) {
+    return cloneDiscordBotConfig(DEFAULT_DISCORD_BOT_CONFIG);
+  }
+  let value = raw;
+  if (typeof raw === 'string') {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      value = {};
+    }
+  }
+  return cloneDiscordBotConfig(value);
+}
+
+export function encodeDiscordBotConfig(config) {
+  const normalised = normaliseDiscordBotConfig(config);
+  return JSON.stringify({
+    presenceTemplate: normalised.presenceTemplate,
+    presenceStatuses: normalised.presenceStatuses,
+    colors: normalised.colors,
+    fields: normalised.fields
+  });
+}
+
+export function discordBotConfigKey(config) {
+  return encodeDiscordBotConfig(config);
+}
+
+export function renderPresenceTemplate(template, context) {
+  const baseTemplate = sanitizePresenceTemplate(template);
+  const text = baseTemplate.replace(/\{(\w+)\}/g, (match, token) => {
+    if (Object.hasOwn(context, token)) {
+      const value = context[token];
+      return value == null ? '' : String(value);
+    }
+    return '';
+  });
+  const cleaned = text.trim();
+  if (cleaned.length === 0) {
+    return sanitizePresenceTemplate(DEFAULT_DISCORD_BOT_CONFIG.presenceTemplate);
+  }
+  return cleaned.slice(0, 120);
+}
+
+export function describePresenceTemplateUsage() {
+  const parts = PRESENCE_TEMPLATE_TOKENS.map((token) => `\`{${token}}\``);
+  return parts.join(', ');
+}


### PR DESCRIPTION
## Summary
- add shared Discord bot configuration helpers with defaults, validation, and formatting utilities
- extend the Discord bot service with slash command configuration, dynamic presence templates, and configurable status embeds
- persist Discord integration settings in SQLite/MySQL and expose the config via the server API

## Testing
- node --check backend/src/discord-bot-service.js
- node --check backend/src/index.js
- node --check backend/src/discord-config.js

------
https://chatgpt.com/codex/tasks/task_e_68d84ed1861c8331981c42b14af3da0e