### PR TITLE
Fix infinite recursion in Discord config normalisation

### DIFF
--- a/backend/src/discord-config.js
+++ b/backend/src/discord-config.js
@@ -120,7 +120,6 @@ function normalizeColors(colors = {}) {
 }
 
 export function normaliseDiscordBotConfig(value = {}) {
-  if (value === DEFAULT_DISCORD_BOT_CONFIG) return cloneDiscordBotConfig(value);
   const source = typeof value === 'object' && value != null ? value : {};
   return {
     presenceTemplate: sanitizePresenceTemplate(source.presenceTemplate ?? source.presence_template),


### PR DESCRIPTION
## Summary
- prevent `normaliseDiscordBotConfig` from recursing when given the default config instance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d85d70150883318acc1d91a99c751e