### PR TITLE
Show IP country and last ban details in player UI

### DIFF
--- a/frontend/assets/js/panel-shell.js
+++ b/frontend/assets/js/panel-shell.js
@@ -18,16 +18,25 @@
     const steamProfileUrl = profile.profileUrl || (steamIdValue ? `https://steamcommunity.com/profiles/${encodeURIComponent(steamIdValue)}` : '');
     const serverArmourUrl = steamIdValue ? `https://serverarmour.com/profile/${encodeURIComponent(steamIdValue)}` : '';
     const playtimeText = formatPlaytime(profile.rustPlaytimeMinutes, profile.visibility);
-    const vacText = profile.vacBanned ? 'Yes' : 'No';
+    const vacBanned = Boolean(profile.vacBanned);
+    const vacText = vacBanned ? 'Yes' : 'No';
     const gameBanCount = Number(profile.gameBans) > 0 ? Number(profile.gameBans) : 0;
+    const hasBanRecord = vacBanned || gameBanCount > 0;
     const rawDaysSinceBan = Number(profile.daysSinceLastBan);
-    const hasBanAge = Number.isFinite(rawDaysSinceBan) && rawDaysSinceBan >= 0;
+    const hasBanAge = hasBanRecord && Number.isFinite(rawDaysSinceBan) && rawDaysSinceBan >= 0;
     const lastBan = hasBanAge
       ? rawDaysSinceBan === 0
         ? 'Today'
         : `${rawDaysSinceBan} day${rawDaysSinceBan === 1 ? '' : 's'} ago`
-      : '—';
+      : (hasBanRecord ? 'Unknown' : '—');
     const ipText = player.ip ? `${player.ip}${player.port ? ':' + player.port : ''}` : 'Hidden';
+    const ipCountryCode = player.ip_country_code || player.ipCountryCode || '';
+    const steamCountryCode = profile.country || '';
+    const hasIpCountry = Boolean(ipCountryCode);
+    const countryLabel = ipCountryCode || steamCountryCode || '—';
+    const steamCountrySuffix = hasIpCountry && steamCountryCode && steamCountryCode !== ipCountryCode
+      ? ` (Steam: ${steamCountryCode})`
+      : '';
     const position = player.position || player.Position || {};
     const positionText = `${Math.round(position.x ?? 0)}, ${Math.round(position.z ?? 0)}`;
     const nameValue = escapeHtml(displayName);
@@ -47,9 +56,9 @@
       <div class="kv"><div class="k">Ping:</div><div>${Math.round(player.ping ?? player.Ping ?? 0)} ms</div></div>
       <div class="kv"><div class="k">Connected:</div><div>${formatConnected(player.connectedSeconds ?? player.ConnectedSeconds)}</div></div>
       <div class="kv"><div class="k">Rust playtime:</div><div>${playtimeText}</div></div>
-      <div class="kv"><div class="k">VAC ban:</div><div>${vacText}</div></div>
-      <div class="kv"><div class="k">Game bans:</div><div>${gameBanCount || '0'}${gameBanCount ? ` (${lastBan})` : ''}</div></div>
-      <div class="kv"><div class="k">Country:</div><div>${escapeHtml(profile.country || '—')}</div></div>
+      <div class="kv"><div class="k">VAC ban:</div><div>${vacText}${vacBanned ? ` (${escapeHtml(lastBan)})` : ''}</div></div>
+      <div class="kv"><div class="k">Game bans:</div><div>${gameBanCount || '0'}${gameBanCount > 0 ? ` (${escapeHtml(lastBan)})` : ''}</div></div>
+      <div class="kv"><div class="k">Country:</div><div>${escapeHtml(countryLabel)}${escapeHtml(steamCountrySuffix)}</div></div>
       <div class="kv"><div class="k">Address:</div><div>${escapeHtml(ipText)}</div></div>
       <div class="kv"><div class="k">Position:</div><div>(${positionText})</div></div>
       ${actionsBlock}


### PR DESCRIPTION
## Summary
- prefer the IP-derived country code on the live players list and player info panel
- keep the latest ban age when a player has either a VAC or game ban and surface it in badges/details
- avoid discarding ban age data when normalising external player records

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d85a9872548331b9be1def616c1a46