### PR TITLE
Normalize world size parsing and resume RustMaps requests

### DIFF
--- a/backend/src/rustmaps.js
+++ b/backend/src/rustmaps.js
@@ -14,7 +14,14 @@ function ensureApiKey(apiKey) {
 }
 
 function toInt(value) {
-  const num = Number(value);
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'bigint') return Number(value);
+  const text = String(value).trim();
+  if (!text) return null;
+  const normalised = text.replace(/[_\s,]/g, '');
+  if (!normalised) return null;
+  const num = Number(normalised);
   return Number.isFinite(num) ? Math.trunc(num) : null;
 }
 

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2129,6 +2129,42 @@ button.menu-tab.active {
   min-height: 420px;
 }
 
+.map-placeholder {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 18px;
+  padding: 32px 24px;
+  text-align: center;
+  background: rgba(9, 1, 4, 0.94);
+  color: var(--muted);
+  font-size: 0.96rem;
+  line-height: 1.5;
+  z-index: 2;
+}
+
+.map-placeholder .map-status {
+  width: min(100%, 420px);
+  margin: 0 auto;
+}
+
+.map-placeholder-text {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.map-view.map-view-has-message > .map-placeholder {
+  display: flex;
+}
+
+.map-view.map-view-has-message > img,
+.map-view.map-view-has-message > .map-overlay {
+  display: none;
+}
+
 .map-view img {
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- normalise RustMaps integer parsing and map key derivation so comma-formatted world size and seed values still trigger metadata lookups
- adjust the live map frontend parsing helpers to accept formatted world details and display raw numeric values without commas
- ensure world detail extraction reuses the sanitised numeric parsing so cached metadata is reused and new imagery requests are issued when needed
- fix the RCON fallback world size/seed parsing to treat comma-separated numbers as full values so automatic RustMaps requests fire when serverinfo misses details

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d86089d3608331abf70c7045f55231