### PR TITLE
Refine team selector copy and styling

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -714,13 +714,18 @@
   function renderUserDetails(user) {
     if (!userDetailsPanel || !user) return;
     const isSelf = user.id === state.currentUser?.id;
-    if (userDetailsName) userDetailsName.textContent = user.username;
+    const roleLabel = formatUserRole(user);
+    if (userDetailsName) {
+      const baseName = user.username || '—';
+      userDetailsName.textContent = roleLabel && roleLabel !== '—'
+        ? `${baseName} (${roleLabel})`
+        : baseName;
+    }
     if (userDetailsSubtitle) {
       userDetailsSubtitle.textContent = isSelf
         ? 'Signed in with this account'
         : 'Review access and credentials';
     }
-    const roleLabel = formatUserRole(user);
     if (userDetailsRole) userDetailsRole.textContent = roleLabel;
     if (userDetailsRoleBadge) userDetailsRoleBadge.textContent = roleLabel;
     if (userDetailsCreated) userDetailsCreated.textContent = formatUserJoined(user.created_at);

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -625,14 +625,45 @@ label.inline input[type="checkbox"]:focus-visible,
 
 .team-switcher.hidden { display: none; }
 
+.team-select-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.team-select-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--muted);
+}
+
 .team-switcher select {
-  padding: 6px 14px;
+  padding: 6px 34px 6px 14px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--card-border);
   background: rgba(15, 23, 42, 0.7);
   color: var(--text);
   font-size: 0.95rem;
   min-width: 180px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: none;
+}
+
+.team-select-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.team-select-arrow {
+  position: absolute;
+  right: 12px;
+  pointer-events: none;
+  font-size: 0.7rem;
+  color: var(--muted);
 }
 
 .server-grid {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,8 +67,13 @@
         </div>
         <div class="header-controls">
           <div id="teamSwitcher" class="team-switcher hidden" aria-hidden="true">
-            <label class="sr-only" for="teamSelect">Select team</label>
-            <select id="teamSelect" aria-label="Select active team"></select>
+            <div class="team-select-group">
+              <label class="team-select-label" for="teamSelect">Username (owner)</label>
+              <div class="team-select-wrap">
+                <select id="teamSelect"></select>
+                <span class="team-select-arrow" aria-hidden="true">▾</span>
+              </div>
+            </div>
           </div>
           <nav id="mainNav" class="topnav hidden" aria-label="Application navigation">
             <button id="navDashboard" type="button" class="nav-btn active">Dashboard</button>


### PR DESCRIPTION
## Summary
- revert the sign-in username label to its original copy
- show "Username (owner)" above the team selector and keep a subtle arrow indicator
- style the selector label and arrow to match the header controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8d6fafcc83318e3717d100e637ec