### PR TITLE
Avoid logging duplicate command replies in console

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -3536,7 +3536,12 @@
     try {
       const reply = await runRconCommand(cmd);
       ui.log('> ' + cmd);
-      if (reply?.Message) ui.log(reply.Message.trim());
+      const shouldEchoReply = !socket?.connected
+        || !hasServerCapability('console')
+        || !canAccessServerId(state.currentServerId);
+      if (reply?.Message && shouldEchoReply) {
+        ui.log(reply.Message.trim());
+      }
       cmdInput.value = '';
     } catch (err) {
       if (errorCode(err) === 'no_server_selected') {


### PR DESCRIPTION
## Summary
- avoid echoing command replies locally when the live console stream is active so command results do not appear twice

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dac879af9c8331883d20c237445c0b