### PR TITLE
Add fullscreen map view and improve live map refresh

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -208,7 +208,9 @@ main.grid{
 }
 .map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
 .map-layout{display:flex; flex-direction:column; gap:18px}
+.live-map-card .map-layout{max-width:960px;margin:0 auto}
 .map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7)}
+.live-map-card .map-view{min-height:clamp(260px,45vh,420px)}
 .map-view img{display:block; width:100%; height:auto}
 .map-overlay{position:absolute; inset:0; pointer-events:none}
 .map-overlay .map-marker{position:absolute; width:12px; height:12px; border-radius:999px; transform:translate(-50%,-50%); box-shadow:0 0 12px rgba(0,0,0,.4); border:2px solid rgba(0,0,0,.45)}
@@ -220,6 +222,7 @@ main.grid{
 .map-sidebar .row{display:flex; justify-content:flex-end}
 .map-sidebar .row button{border-radius:999px}
 .map-player-list{overflow-x:auto}
+.live-map-card .map-player-list{max-height:clamp(240px,48vh,520px); overflow-y:auto}
 .map-player-table{width:100%; min-width:420px; border-collapse:collapse; font-size:.9rem}
 .map-player-table thead th{
   text-align:left; font-size:.7rem; text-transform:uppercase; letter-spacing:.06em;
@@ -229,6 +232,8 @@ main.grid{
 .map-player-list button:hover{background:rgba(225,29,72,.12); border-color:rgba(225,29,72,.35)}
 .map-player-list button.active{background:rgba(225,29,72,.18); border-color:rgba(225,29,72,.55)}
 .map-player-list button.dimmed{opacity:.6}
+.map-fullscreen-button{border-radius:999px;padding:6px 14px;font-size:.9rem;font-weight:500;display:inline-flex;align-items:center;gap:8px}
+.map-fullscreen-button::after{content:"\1F5D6";font-size:1rem}
 .map-player-tag{display:flex; gap:8px; color:var(--muted); font-size:12px}
 .map-player-table tbody td{padding:10px; border-bottom:1px solid rgba(15,23,42,.65)}
 .map-player-table tbody tr{cursor:pointer; transition:background .15s ease, color .15s ease}
@@ -246,6 +251,7 @@ main.grid{
 .map-team-info{display:flex; flex-direction:column; gap:10px; background:rgba(15,19,28,.78); border-radius:12px; padding:14px; border:1px solid rgba(148,163,184,.1)}
 .map-team-info .team-row{display:flex; align-items:center; justify-content:space-between; gap:12px}
 .map-team-info .team-color{width:14px; height:14px; border-radius:50%; border:2px solid rgba(15,23,42,.6)}
+.map-color-chip{display:inline-block;width:14px;height:14px;border-radius:50%;border:2px solid rgba(15,23,42,.6);vertical-align:middle}
 .map-upload{border:1px dashed rgba(148,163,184,.25); border-radius:12px; padding:16px; background:rgba(17,20,30,.6); display:flex; flex-direction:column; gap:12px}
 .map-upload-actions{display:flex; gap:10px; flex-wrap:wrap}
 .map-upload input[type="file"]{color:var(--muted)}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2197,6 +2197,11 @@ button.menu-tab.active {
   align-items: start;
 }
 
+.live-map-card .map-layout {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
 @media (max-width: 1200px) {
   .map-layout { grid-template-columns: 1fr; }
 }
@@ -2208,6 +2213,10 @@ button.menu-tab.active {
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(9, 1, 4, 0.9);
   min-height: 420px;
+}
+
+.live-map-card .map-view {
+  min-height: clamp(260px, 45vh, 420px);
 }
 
 .map-placeholder {
@@ -2277,6 +2286,26 @@ button.menu-tab.active {
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+.live-map-card .map-player-list {
+  max-height: clamp(240px, 48vh, 520px);
+  overflow-y: auto;
+}
+
+.map-fullscreen-button {
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.map-fullscreen-button::after {
+  content: '\1F5D6';
+  font-size: 1rem;
 }
 
 .settings-card .card-header p {
@@ -2516,6 +2545,15 @@ button.menu-tab.active {
   border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--muted);
   font-size: 0.88rem;
+}
+
+.map-color-chip {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.6);
+  vertical-align: middle;
 }
 
 .map-config {


### PR DESCRIPTION
## Summary
- add a fullscreen popup option for the live map and share rendering across standard and popup views
- streamline live map updates so player refreshes avoid unnecessary map reflows
- tweak live map styling for a more compact layout and dedicated fullscreen control styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dac90817b48331977144a022faef29