### PR TITLE
Avoid refreshing map image after successful fetch

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -208,6 +208,7 @@
       let mapImageSource = null;
       let mapImageObjectUrl = null;
       let mapImageAbort = null;
+      let mapImageLocked = false;
       const FULLSCREEN_WINDOW_FEATURES = 'width=1280,height=720,menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes';
       const FULLSCREEN_STYLES = `
         :root { color-scheme: dark; }
@@ -770,6 +771,12 @@
         const awaitingUpload = state.status === 'awaiting_upload';
         const awaitingServerInfo = state.status === 'awaiting_server_info';
         const rustmapsMissing = state.status === 'rustmaps_not_found' || meta?.notFound;
+        const ready = hasImage && mapReady();
+
+        if (ready) {
+          clearMessage();
+          return;
+        }
 
         if (awaitingServerInfo) {
           showStatusMessage('Waiting for world details from the server…', {
@@ -1287,6 +1294,7 @@
         }
         mapImageObjectUrl = null;
         mapImageSource = null;
+        mapImageLocked = false;
         mapImage.removeAttribute('src');
         if (isFullscreenOpen() && fullscreenViewport?.mapImage) {
           fullscreenViewport.mapImage.removeAttribute('src');
@@ -1311,7 +1319,7 @@
 
       async function fetchAuthorizedImage(path, controller) {
         if (typeof ctx.authorizedFetch !== 'function') {
-          return { url: resolveImageUrl(path) };
+          return { url: resolveImageUrl(path), status: 200 };
         }
         const res = await ctx.authorizedFetch(path, {
           signal: controller.signal,
@@ -1324,7 +1332,7 @@
           throw error;
         }
         const blob = await res.blob();
-        return { blob };
+        return { blob, status: res.status };
       }
 
       function applyBlobToImage(blob) {
@@ -1352,6 +1360,7 @@
           clearMapImage();
           return;
         }
+        if (mapImageLocked) return;
         const next = meta.imageUrl;
         if (!next) {
           cancelMapImageRequest();
@@ -1371,6 +1380,9 @@
           if (mapImageAbort !== controller) return;
           if (result.blob) {
             applyBlobToImage(result.blob);
+            if (result.status === 200) {
+              mapImageLocked = true;
+            }
           } else if (result.url) {
             clearMapImage();
             mapImage.src = result.url;
@@ -1378,6 +1390,9 @@
               fullscreenViewport.mapImage.src = result.url;
             }
             mapImageSource = next;
+            if (result.status === 200) {
+              mapImageLocked = true;
+            }
           }
         } catch (err) {
           if (mapImageAbort !== controller) return;
@@ -1812,7 +1827,7 @@
           const previousRemote = previousMeta?.remoteImage ?? null;
           const previousCustom = previousMeta?.custom ?? null;
           let mapChanged = false;
-          const allowMapRefresh = reason !== 'player-reload';
+          const allowMapRefresh = reason !== 'player-reload' && reason !== 'poll';
           const hasMapField = data && Object.prototype.hasOwnProperty.call(data, 'map');
           if (hasMapField) {
             const nextMeta = data?.map || null;
@@ -1880,7 +1895,7 @@
           updateConfigPanel();
           updateUploadSection();
           updateStatusMessage(hasImage);
-          if (reason === 'player-reload') {
+          if (reason === 'player-reload' || reason === 'poll') {
             renderPlayerSections();
           } else {
             renderAll();


### PR DESCRIPTION
## Summary
- add a lock flag to prevent re-requesting or resetting the live map image once a successful 200 response is received
- reset the lock whenever the image is cleared so new maps can still load while keeping the current image stable otherwise
- suppress the fallback status overlay once the map image and metadata are ready so player refreshes don’t blank the map

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad6a9e18883318677bc0b5ec47c8c