### PR TITLE
Handle custom map level URLs before RustMaps fetch

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -833,6 +833,49 @@ function extractFloat(value) {
   return Number.isFinite(num) ? num : null;
 }
 
+function parseLevelUrlMessage(message) {
+  if (message == null) return null;
+  const text = String(message).trim();
+  if (!text) return null;
+
+  try {
+    const json = JSON.parse(text);
+    if (typeof json === 'string') {
+      const parsed = json.trim();
+      if (parsed) return parsed;
+    }
+    if (json && typeof json === 'object') {
+      for (const value of Object.values(json)) {
+        const nested = parseLevelUrlMessage(value);
+        if (nested) return nested;
+      }
+    }
+  } catch {
+    // not JSON, continue with pattern-based parsing
+  }
+
+  const quotedMatch = text.match(/["']\s*(https?:\/\/[^"']+?)\s*["']/i);
+  if (quotedMatch && quotedMatch[1]) {
+    return quotedMatch[1].trim();
+  }
+
+  const urlMatch = text.match(/https?:\/\/\S+/i);
+  if (urlMatch && urlMatch[0]) {
+    return urlMatch[0].replace(/["'\s>;\]]+$/, '').trim();
+  }
+
+  const colonIndex = text.indexOf(':');
+  if (colonIndex >= 0) {
+    const candidate = text.slice(colonIndex + 1).trim()
+      .replace(/^["']+/, '')
+      .replace(/["',;>\]]+$/, '')
+      .trim();
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
 function parseServerInfoMessage(message) {
   const result = { raw: message, mapName: null, size: null, seed: null, fps: null };
   if (!message) return { ...result };
@@ -863,10 +906,15 @@ function parseServerInfoMessage(message) {
       if (seed != null) result.seed = seed;
     }
     if (lower.includes('level') && lower.includes('url')) {
-      if (!result.levelUrl && typeof trimmedValue === 'string' && trimmedValue.trim()) {
-        result.levelUrl = trimmedValue.trim();
-      } else if (!result.levelUrl && trimmedValue != null && trimmedValue !== '') {
-        result.levelUrl = String(trimmedValue).trim();
+      if (!result.levelUrl) {
+        const parsed = parseLevelUrlMessage(trimmedValue);
+        if (parsed) {
+          result.levelUrl = parsed;
+        } else if (typeof trimmedValue === 'string' && trimmedValue.trim()) {
+          result.levelUrl = trimmedValue.trim();
+        } else if (trimmedValue != null && trimmedValue !== '') {
+          result.levelUrl = String(trimmedValue).trim();
+        }
       }
     }
     if (lower.includes('fps') || lower.includes('framerate')) {
@@ -964,14 +1012,17 @@ function parseServerInfoMessage(message) {
       fields['Level URL']
     ];
     for (const candidate of candidates) {
-      if (typeof candidate === 'string') {
-        const trimmed = candidate.trim();
-        if (trimmed) {
-          output.levelUrl = trimmed;
-          break;
-        }
+      const parsed = parseLevelUrlMessage(candidate);
+      if (parsed) {
+        output.levelUrl = parsed;
+        break;
       }
     }
+  }
+
+  if (!output.levelUrl) {
+    const parsed = parseLevelUrlMessage(trimmed);
+    if (parsed) output.levelUrl = parsed;
   }
 
   if (output.fps == null) {
@@ -2736,6 +2787,24 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
         logger.warn('Failed to fetch serverinfo via RCON', err);
       }
     }
+    let levelUrl = typeof info?.levelUrl === 'string' ? info.levelUrl.trim() : '';
+    if (!levelUrl) {
+      try {
+        const reply = await sendRconCommand(server, 'levelurl', { silent: true });
+        const parsedLevelUrl = parseLevelUrlMessage(reply?.Message || reply?.message || '');
+        if (parsedLevelUrl) {
+          levelUrl = parsedLevelUrl;
+          if (info) {
+            info.levelUrl = levelUrl;
+            cacheServerInfo(id, info);
+          }
+        }
+      } catch (err) {
+        logger.warn('Failed to fetch level URL via RCON', err);
+      }
+    }
+    const hasLevelUrl = levelUrl.length > 0;
+
     if (!info?.size || !info?.seed) {
       try {
         const { size, seed } = await fetchSizeAndSeedViaRcon(server);
@@ -2755,6 +2824,13 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       logger.info('Existing map record expired, removing cached image');
       await removeMapImage(mapRecord);
       if (!mapRecord.custom && mapRecord.map_key) await removeGlobalMapMetadata(mapRecord.map_key);
+      await db.deleteServerMap(id);
+      mapRecord = null;
+    }
+    if (mapRecord && !mapRecord.custom && hasLevelUrl) {
+      logger.info('Server reports custom level URL, clearing procedural map cache');
+      await removeMapImage(mapRecord);
+      if (mapRecord.map_key) await removeGlobalMapMetadata(mapRecord.map_key);
       await db.deleteServerMap(id);
       mapRecord = null;
     }
@@ -2800,9 +2876,25 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
     }
 
     let map = mapRecordToPayload(id, mapRecord, mapMetadata);
+    if (!map && hasLevelUrl) {
+      const baseKey = infoMapKey || null;
+      const customKey = baseKey ? `${baseKey}-server-${id}` : `server-${id}-custom`;
+      map = {
+        mapKey: customKey,
+        custom: true,
+        cached: false,
+        cachedAt: null,
+        imageUrl: null,
+        needsUpload: true,
+        levelUrl
+      };
+      if (Number.isFinite(info?.size)) map.size = info.size;
+      if (Number.isFinite(info?.seed)) map.seed = info.seed;
+      if (info?.mapName) map.mapName = info.mapName;
+    }
     if (map && !map.mapKey && infoMapKey) map.mapKey = infoMapKey;
     if (!map) {
-      if (info?.size && info?.seed) {
+      if (!hasLevelUrl && info?.size && info?.seed) {
         const userKey = await db.getUserSetting(req.user.uid, 'rustmaps_api_key');
         const apiKey = userKey || DEFAULT_RUSTMAPS_API_KEY || '';
         try {


### PR DESCRIPTION
## Summary
- detect custom level URLs reported by the server and treat them as manual map uploads
- clear cached procedural map data when a server switches to a custom map
- skip RustMaps lookups for custom maps and surface metadata that prompts an image upload
- fetch the server's level URL via the `levelurl` RCON command when it is not already cached

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae6770c3083319f6bb92c7f261b1e