### PR TITLE
Improve level URL detection around timestamped RCON output

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -44,6 +44,8 @@ const MAX_MAP_IMAGE_BYTES = 20 * 1024 * 1024;
 
 const FACEPUNCH_LEVEL_HOST_PATTERN = /^https?:\/\/files\.facepunch\.com/i;
 const LEVEL_URL_PATTERN = /^https?:\/\/\S+/i;
+const LEVEL_URL_INLINE_PATTERN = /https?:\/\/\S+/i;
+const ANSI_ESCAPE_SEQUENCE_PATTERN = /\u001b\[[0-?]*[ -\/]*[@-~]/g;
 
 const mapImageUpload = multer({
   storage: multer.memoryStorage(),
@@ -108,6 +110,46 @@ function resolveIpCountry(ip) {
     code,
     name: countryNameFromCode(code)
   };
+}
+
+function stripAnsiSequences(value) {
+  if (typeof value !== 'string' || !value) return value;
+  return value.replace(ANSI_ESCAPE_SEQUENCE_PATTERN, '');
+}
+
+function stripRconTimestampPrefix(value) {
+  if (typeof value !== 'string' || !value) return value;
+  let result = value;
+  let attempts = 0;
+  const MAX_ATTEMPTS = 4;
+  while (attempts < MAX_ATTEMPTS) {
+    attempts += 1;
+    let modified = false;
+    const bracketMatch = result.match(/^\s*\[[^\]]*\]\s*/);
+    if (bracketMatch) {
+      const inner = bracketMatch[0].replace(/^\s*\[|\]\s*$/g, '');
+      if (/\d{1,4}[-/:]\d{1,2}[-/:]\d{1,4}/.test(inner) || /\d{1,2}:\d{2}/.test(inner)) {
+        result = result.slice(bracketMatch[0].length);
+        modified = true;
+      }
+    }
+    if (!modified) {
+      const trailingMatch = result.match(/^\s*\d{1,2}:\d{2}(?::\d{2})?\s*(?:AM|PM)?]\s*/i);
+      if (trailingMatch) {
+        result = result.slice(trailingMatch[0].length);
+        modified = true;
+      }
+    }
+    if (!modified) break;
+  }
+  return result;
+}
+
+function normaliseRconLine(line) {
+  if (typeof line !== 'string') return '';
+  const withoutAnsi = stripAnsiSequences(line);
+  const withoutTimestamp = stripRconTimestampPrefix(withoutAnsi);
+  return withoutTimestamp.replace(/^\s*>+\s*/, '');
 }
 
 const app = express();
@@ -854,11 +896,13 @@ function isCustomLevelUrl(value) {
 
 function parseLevelUrlMessage(message) {
   if (message == null) return null;
-  const text = String(message).trim();
-  if (!text) return null;
+  const text = stripAnsiSequences(String(message));
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const normalized = stripRconTimestampPrefix(trimmed).trim() || trimmed;
 
   try {
-    const json = JSON.parse(text);
+    const json = JSON.parse(normalized);
     if (typeof json === 'string') {
       const parsed = json.trim();
       if (parsed && isLikelyLevelUrl(parsed)) return parsed;
@@ -873,21 +917,34 @@ function parseLevelUrlMessage(message) {
     // not JSON, continue with pattern-based parsing
   }
 
-  const quotedMatch = text.match(/["']\s*(https?:\/\/[^"']+?)\s*["']/i);
+  const quotedMatch = normalized.match(/["']\s*(https?:\/\/[^"']+?)\s*["']/i);
   if (quotedMatch && quotedMatch[1]) {
     const candidate = quotedMatch[1].trim();
     if (isLikelyLevelUrl(candidate)) return candidate;
   }
 
-  const urlMatch = text.match(LEVEL_URL_PATTERN);
+  const urlMatch = normalized.match(LEVEL_URL_INLINE_PATTERN);
   if (urlMatch && urlMatch[0]) {
     const candidate = urlMatch[0].replace(/["'\s>;\]]+$/, '').trim();
     if (isLikelyLevelUrl(candidate)) return candidate;
   }
 
-  const colonIndex = text.indexOf(':');
+  const colonIndex = normalized.toLowerCase().indexOf('levelurl');
   if (colonIndex >= 0) {
-    const candidate = text.slice(colonIndex + 1).trim()
+    const afterKey = normalized.slice(colonIndex + 'levelurl'.length);
+    const separatorIndex = afterKey.indexOf(':');
+    if (separatorIndex >= 0) {
+      const candidate = afterKey.slice(separatorIndex + 1).trim()
+        .replace(/^["']+/, '')
+        .replace(/["',;>\]]+$/, '')
+        .trim();
+      if (candidate && isLikelyLevelUrl(candidate)) return candidate;
+    }
+  }
+
+  const genericColonIndex = normalized.indexOf(':');
+  if (genericColonIndex >= 0) {
+    const candidate = normalized.slice(genericColonIndex + 1).trim()
       .replace(/^["']+/, '')
       .replace(/["',;>\]]+$/, '')
       .trim();
@@ -932,6 +989,16 @@ function parseServerInfoMessage(message) {
         if (parsed) result.levelUrl = parsed;
       }
     }
+    if (!result.levelUrl && typeof trimmedValue === 'string') {
+      const candidateText = trimmedValue.trim();
+      if (candidateText) {
+        const lowerValue = candidateText.toLowerCase();
+        if (lowerValue.includes('levelurl') || LEVEL_URL_PATTERN.test(candidateText)) {
+          const parsed = parseLevelUrlMessage(candidateText);
+          if (parsed) result.levelUrl = parsed;
+        }
+      }
+    }
     if (lower.includes('fps') || lower.includes('framerate')) {
       const fpsValue = extractFloat(trimmedValue);
       if (fpsValue != null) result.fps = fpsValue;
@@ -953,7 +1020,9 @@ function parseServerInfoMessage(message) {
 
   if (!parsedJson) {
     const lines = trimmed.split(/\r?\n/);
-    for (const line of lines) {
+    for (const rawLine of lines) {
+      const line = normaliseRconLine(rawLine);
+      if (!line.trim()) continue;
       const match = line.match(/^\s*([^:=\t]+?)\s*(?:[:=]\s*|\s{2,}|\t+)(.+)$/);
       if (match) {
         assign(match[1], match[2]);


### PR DESCRIPTION
## Summary
- strip ANSI colour codes and timestamp prefixes before parsing level URL replies
- normalise serverinfo lines so levelurl entries survive timestamped or prompt-prefixed output
- fall back to scanning value text for URLs when the parsed key is malformed

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc235983388331aeed86fe54140e30