### PR TITLE
Prioritize panel meta tag for default API base

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1325,12 +1325,10 @@
   }
 
   function detectDefaultApiBase() {
-    const stored = normalizeApiBase(localStorage.getItem('apiBase'));
-    if (stored) return stored;
-
     const hasWindow = typeof window !== 'undefined' && window?.location;
-    const metaContent = document.querySelector('meta[name="panel-api-base"]')?.content?.trim();
+    const stored = normalizeApiBase(localStorage.getItem('apiBase'));
 
+    const metaContent = document.querySelector('meta[name="panel-api-base"]')?.content?.trim();
     if (metaContent) {
       if (hasWindow) {
         try {
@@ -1346,6 +1344,8 @@
         if (normalizedMeta) return normalizedMeta;
       }
     }
+
+    if (stored) return stored;
 
     if (hasWindow && window.location?.origin) {
       const normalizedOrigin = normalizeApiBase(window.location.origin);


### PR DESCRIPTION
## Summary
- ensure the frontend prefers the panel-provided meta tag when choosing an API base URL
- keep stored overrides as a fallback so browsers stop clinging to legacy :8787 defaults

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcb3093d9c8331a50f4487b30d9405