### PR TITLE
Keep custom map URLs alive during cache gaps

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1886,12 +1886,23 @@ async function purgeExpiredMapCaches(now = new Date()) {
   await purgeGlobalCacheIfDue(resetPoint, now, activeImages, activeMapKeys);
 }
 
+function parseMapRecordData(record) {
+  if (!record) return null;
+  const raw = record.data;
+  if (!raw) return null;
+  try {
+    if (typeof raw === 'string') return JSON.parse(raw);
+    if (typeof raw === 'object') return { ...raw };
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 function mapRecordToPayload(serverId, record, metadataOverride = null) {
   if (!record) return null;
   let meta = {};
-  if (record.data) {
-    try { meta = JSON.parse(record.data); } catch { /* ignore parse errors */ }
-  }
+  meta = parseMapRecordData(record) || meta;
   if (metadataOverride && typeof metadataOverride === 'object') {
     meta = { ...meta, ...metadataOverride };
   }
@@ -2894,7 +2905,9 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
         logger.warn('Failed to fetch level URL via RCON', err);
       }
     }
-    const hasCustomLevelUrl = isCustomLevelUrl(levelUrl);
+    let hasCustomLevelUrl = isCustomLevelUrl(levelUrl);
+    const derivedMapKey = deriveMapKey(info) || null;
+    let infoMapKey = hasCustomLevelUrl ? null : derivedMapKey;
 
     if (!info?.size || !info?.seed) {
       try {
@@ -2909,8 +2922,18 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
     }
     const now = new Date();
     const resetPoint = firstThursdayResetTime(now);
-    const infoMapKey = deriveMapKey(info) || null;
     let mapRecord = await db.getServerMap(id);
+    if (mapRecord?.custom && levelUrl && !isCustomLevelUrl(levelUrl)) {
+      logger.info('Server reports procedural level URL, clearing custom map cache');
+      await removeMapImage(mapRecord);
+      if (mapRecord.map_key) await removeGlobalMapMetadata(mapRecord.map_key);
+      await db.deleteServerMap(id);
+      mapRecord = null;
+    }
+    if (mapRecord?.custom && !hasCustomLevelUrl && !levelUrl) {
+      hasCustomLevelUrl = true;
+      infoMapKey = null;
+    }
     if (mapRecord && shouldResetMapRecord(mapRecord, now, resetPoint)) {
       logger.info('Existing map record expired, removing cached image');
       await removeMapImage(mapRecord);
@@ -2966,22 +2989,60 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       }
     }
 
+    if (mapRecord?.custom && !levelUrl) {
+      const storedMeta = mapMetadata || parseMapRecordData(mapRecord) || {};
+      const storedLevelUrl = typeof storedMeta.levelUrl === 'string' ? storedMeta.levelUrl.trim() : '';
+      if (isCustomLevelUrl(storedLevelUrl)) {
+        levelUrl = storedLevelUrl;
+        hasCustomLevelUrl = true;
+        infoMapKey = null;
+        if (info) {
+          const cachedLevelUrl = typeof info.levelUrl === 'string' ? info.levelUrl.trim() : '';
+          if (cachedLevelUrl !== storedLevelUrl) {
+            info.levelUrl = storedLevelUrl;
+            cacheServerInfo(id, info);
+          }
+        }
+      }
+    }
+
     let map = mapRecordToPayload(id, mapRecord, mapMetadata);
     if (!map && hasCustomLevelUrl) {
-      const baseKey = infoMapKey || null;
+      const baseKey = derivedMapKey;
       const customKey = baseKey ? `${baseKey}-server-${id}` : `server-${id}-custom`;
-      map = {
-        mapKey: customKey,
-        custom: true,
-        cached: false,
-        cachedAt: null,
-        imageUrl: null,
-        needsUpload: true,
-        levelUrl
-      };
-      if (Number.isFinite(info?.size)) map.size = info.size;
-      if (Number.isFinite(info?.seed)) map.seed = info.seed;
-      if (info?.mapName) map.mapName = info.mapName;
+      const storedMeta = { mapKey: customKey };
+      if (Number.isFinite(info?.size)) storedMeta.size = info.size;
+      if (Number.isFinite(info?.seed)) storedMeta.seed = info.seed;
+      if (info?.mapName) storedMeta.mapName = info.mapName;
+      if (levelUrl) storedMeta.levelUrl = levelUrl;
+      storedMeta.cachedAt = new Date().toISOString();
+      try {
+        await db.saveServerMap(id, {
+          map_key: customKey,
+          data: JSON.stringify(storedMeta),
+          image_path: null,
+          custom: 1
+        });
+        mapRecord = await db.getServerMap(id);
+        const persisted = mapRecordToPayload(id, mapRecord, storedMeta);
+        if (persisted) map = persisted;
+      } catch (err) {
+        logger.warn('Failed to persist custom map placeholder', err);
+      }
+      if (!map) {
+        map = {
+          mapKey: customKey,
+          custom: true,
+          cached: false,
+          cachedAt: storedMeta.cachedAt,
+          imageUrl: null,
+          needsUpload: true,
+          levelUrl
+        };
+        if (Number.isFinite(info?.size)) map.size = info.size;
+        if (Number.isFinite(info?.seed)) map.seed = info.seed;
+        if (info?.mapName) map.mapName = info.mapName;
+      }
     }
     if (map && !map.mapKey && infoMapKey) map.mapKey = infoMapKey;
     if (!map) {


### PR DESCRIPTION
## Summary
- add a helper to normalise stored map record metadata
- rehydrate cached custom level URLs when the live map endpoint receives an empty value so the server info stays flagged as custom

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcb651a9948331a3dcae281eadd668