### PR TITLE
Fix live map pending refresh scheduling

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -2205,7 +2205,7 @@
             clearPendingRefresh();
           } else if (state.status === 'pending' || awaitingImagery) {
             // RustMaps is generating or we're waiting for imagery
-            if (!state.pendingGeneration) schedulePendingRefresh();
+            if (!state.pendingRefresh) schedulePendingRefresh();
             state.pendingGeneration = true;
           } else {
             // Have imagery or no generation required


### PR DESCRIPTION
## Summary
- ensure the live map module keeps rescheduling RustMaps polling while imagery is pending

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df7be6fd74833188b1b78db7884c32