### PR TITLE
Improve live map zoom controls

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -212,13 +212,23 @@ main.grid{
 .map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7)}
 .live-map-card .map-view{min-height:clamp(260px,45vh,420px)}
 .map-view img{display:block; width:100%; height:auto}
-.map-overlay{position:absolute; inset:0; pointer-events:none}
-.map-overlay .map-marker{position:absolute; width:12px; height:12px; border-radius:999px; transform:translate(-50%,-50%); box-shadow:0 0 12px rgba(0,0,0,.4); border:2px solid rgba(0,0,0,.45)}
+.map-overlay{position:absolute; inset:0; pointer-events:none; --marker-scale:1}
+.map-overlay .map-marker{position:absolute; width:clamp(4px, calc(12px * var(--marker-scale)), 12px); height:clamp(4px, calc(12px * var(--marker-scale)), 12px); border-radius:999px; transform:translate(-50%,-50%); box-shadow:0 0 clamp(6px, calc(12px * var(--marker-scale)), 12px) rgba(0,0,0,.4); border:clamp(1px, calc(2px * var(--marker-scale)), 2px) solid rgba(0,0,0,.45)}
 .map-overlay .map-marker.active{box-shadow:0 0 0 3px rgba(225,29,72,.35)}
 .map-overlay .map-marker.dimmed{opacity:.4}
 .map-sidebar{display:flex; flex-direction:column; gap:14px}
 .map-summary{display:grid; gap:6px; background:rgba(15,18,28,.85); border-radius:12px; padding:16px; border:1px solid rgba(148,163,184,.1)}
 .map-summary strong{font-weight:700}
+.map-zoom-control{display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:10px; padding:6px 0}
+.map-zoom-label{font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted)}
+.map-zoom-slider{width:100%}
+.map-zoom-input-wrap{display:inline-flex; align-items:center; gap:4px; padding:4px 10px; border-radius:999px; border:1px solid rgba(148,163,184,.2); background:rgba(15,23,42,.6)}
+.map-zoom-input{width:3.5rem; border:none; background:transparent; color:inherit; text-align:right; font:inherit; appearance:textfield}
+.map-zoom-input:focus{outline:none}
+.map-zoom-input::-webkit-outer-spin-button,.map-zoom-input::-webkit-inner-spin-button{margin:0; appearance:none}
+.map-zoom-unit{font-size:.85rem; color:var(--muted)}
+.map-zoom-control.disabled{opacity:.6}
+.map-zoom-control.disabled .map-zoom-input,.map-zoom-control.disabled .map-zoom-slider{cursor:not-allowed}
 .map-sidebar .row{display:flex; justify-content:flex-end}
 .map-sidebar .row button{border-radius:999px}
 .map-player-list{overflow-x:auto}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2274,22 +2274,23 @@ button.menu-tab.active {
   display: block;
 }
 
-.map-overlay { 
-  position: absolute; 
-  inset: 0; 
-  pointer-events: none; 
+.map-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  --marker-scale: 1;
 }
 
-.map-overlay .map-marker { 
-  position: absolute; 
-  width: 14px; 
-  height: 14px; 
-  border-radius: 50%; 
-  background: var(--accent); 
-  border: 2px solid rgba(0, 0, 0, 0.45); 
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.45); 
-  transform: translate(-50%, -50%); 
-  pointer-events: auto; 
+.map-overlay .map-marker {
+  position: absolute;
+  width: clamp(4px, calc(12px * var(--marker-scale)), 12px);
+  height: clamp(4px, calc(12px * var(--marker-scale)), 12px);
+  border-radius: 50%;
+  background: var(--accent);
+  border: clamp(1px, calc(2px * var(--marker-scale)), 2px) solid rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0 clamp(6px, calc(12px * var(--marker-scale)), 12px) rgba(0, 0, 0, 0.45);
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
 }
 
 .map-overlay .map-marker.active { box-shadow: 0 0 0 3px rgba(244, 63, 94, 0.4); }
@@ -2580,6 +2581,69 @@ button.menu-tab.active {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 0.9rem;
+}
+
+.map-zoom-control {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.map-zoom-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.map-zoom-slider {
+  width: 100%;
+}
+
+.map-zoom-input-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.map-zoom-input {
+  width: 3.5rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: right;
+  font: inherit;
+  appearance: textfield;
+}
+
+.map-zoom-input:focus {
+  outline: none;
+}
+
+.map-zoom-input::-webkit-outer-spin-button,
+.map-zoom-input::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.map-zoom-unit {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.map-zoom-control.disabled {
+  opacity: 0.6;
+}
+
+.map-zoom-control.disabled .map-zoom-input,
+.map-zoom-control.disabled .map-zoom-slider {
+  cursor: not-allowed;
 }
 
 .map-sidebar .row { justify-content: flex-end; }


### PR DESCRIPTION
## Summary
- remove the live map team info tile from the sidebar
- add a range slider and numeric input to smoothly control map zoom level
- scale player markers inversely with zoom for better positioning precision

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0de0c84408331a4cedfa719408614