### PR TITLE
Fix premature Rust map cache purging

### DIFF
--- a/backend/src/rustmaps.js
+++ b/backend/src/rustmaps.js
@@ -251,6 +251,7 @@ export async function purgeRustMapCacheIfDue(
   activeMapKeys = new Set()
 ) {
   if (!resetPoint) return;
+  if (now < resetPoint) return;
   if (lastGlobalMapCacheReset && lastGlobalMapCacheReset >= resetPoint) return;
   await clearRustMapImageCache(activeImages);
   await clearRustMapMetadataCache(activeMapKeys);


### PR DESCRIPTION
## Summary
- prevent the Rust map cache purge from running before the scheduled reset time so cached assets are preserved until the monthly wipe

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0eb4117a08331b113148f780dbf0e