### PR TITLE
Add client-side validation for map upload size

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1079,6 +1079,12 @@
           showUploadNotice('Choose an image before uploading.');
           return;
         }
+        const MAX_MAP_IMAGE_BYTES = 20 * 1024 * 1024;
+        if (typeof file.size === 'number' && file.size > MAX_MAP_IMAGE_BYTES) {
+          showUploadNotice('The image is too large. Please upload a file under 20 MB.');
+          return;
+        }
+
         hideUploadNotice();
         uploadBtn.disabled = true;
         const previousLabel = uploadBtn.textContent;


### PR DESCRIPTION
## Summary
- add a client-side size check before starting the map image upload
- display the existing "image too large" notice immediately when an oversized file is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13149e850833189bee29b214ee656