### PR TITLE
Remove pre-filled default credentials from login inputs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,8 +28,8 @@
         <div class="login-card">
           <h2>Sign in</h2>
           <p class="muted">Enter your credentials to continue.</p>
-          <label>Username<input id="username" value="admin" autocomplete="username"></label>
-          <label>Password<input id="password" type="password" value="admin123" autocomplete="current-password"></label>
+          <label>Username<input id="username" autocomplete="username" placeholder="Username"></label>
+          <label>Password<input id="password" type="password" autocomplete="current-password" placeholder="Password"></label>
           <button id="btnLogin" class="accent">Sign in</button>
           <p id="loginError" class="notice hidden"></p>
           <p class="muted small">Default credentials are for first boot only — change them once you are inside.</p>


### PR DESCRIPTION
## Summary
- remove the hardcoded admin/admin123 values from the login form fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1395e151083318b1ab7b8e852abec