### PR TITLE
Fix live map placeholder layout when map imagery is missing

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -209,9 +209,11 @@ main.grid{
 .map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
 .map-layout{display:flex; flex-direction:column; gap:18px}
 .live-map-card .map-layout{max-width:960px;margin:0 auto}
-.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7)}
+.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7); aspect-ratio:1/1}
+.map-view.map-view-has-message{aspect-ratio:auto}
 .live-map-card .map-view{min-height:clamp(260px,45vh,420px)}
 .map-view img{display:block; width:100%; height:auto}
+.map-placeholder{position:absolute; inset:0; display:none; align-items:center; justify-content:center; flex-direction:column; gap:18px; padding:32px 24px; text-align:center; background:rgba(15,23,42,.86); color:var(--muted); font-size:.96rem; line-height:1.5; z-index:2; overflow:auto}
 .map-overlay{position:absolute; inset:0; pointer-events:none; --marker-scale:1}
 .map-overlay .map-marker{position:absolute; width:clamp(4px, calc(12px * var(--marker-scale)), 12px); height:clamp(4px, calc(12px * var(--marker-scale)), 12px); border-radius:999px; transform:translate(-50%,-50%); box-shadow:0 0 clamp(6px, calc(12px * var(--marker-scale)), 12px) rgba(0,0,0,.4); border:clamp(1px, calc(2px * var(--marker-scale)), 2px) solid rgba(0,0,0,.45)}
 .map-overlay .map-marker.active{box-shadow:0 0 0 3px rgba(225,29,72,.35)}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2233,6 +2233,10 @@ button.menu-tab.active {
   transition: background 0.28s ease, border-color 0.28s ease, box-shadow 0.28s ease;
 }
 
+.map-view.map-view-has-message {
+  aspect-ratio: auto;
+}
+
 .map-view::before {
   content: '';
   position: absolute;
@@ -2289,6 +2293,7 @@ button.menu-tab.active {
   font-size: 0.96rem;
   line-height: 1.5;
   z-index: 2;
+  overflow: auto;
 }
 
 .map-placeholder .map-status {


### PR DESCRIPTION
## Summary
- allow the live map container to drop its aspect ratio when showing placeholder status messages
- let placeholder content scroll to avoid overlapping adjacent server information on the map tab

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1576a2078833181a46d084f37d6e9