### PR TITLE
Fix live map team info rendering

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -259,7 +259,10 @@ main.grid{
 .map-player-stat{text-align:right; font-variant-numeric:tabular-nums}
 .map-filter-note{margin-top:8px}
 .map-team-info{display:flex; flex-direction:column; gap:10px; background:rgba(15,19,28,.78); border-radius:12px; padding:14px; border:1px solid rgba(148,163,184,.1)}
-.map-team-info .team-row{display:flex; align-items:center; justify-content:space-between; gap:12px}
+.map-team-info .team-row{display:flex; align-items:center; justify-content:space-between; gap:12px; padding:4px 0}
+.map-team-info .team-label{display:inline-flex; align-items:center; gap:8px; font-weight:600; color:#e2e8f0}
+.map-team-info .team-detail{color:#cbd5f5; font-variant-numeric:tabular-nums}
+.map-team-info .team-row.active .team-detail{color:#f8fafc}
 .map-team-info .team-color{width:14px; height:14px; border-radius:50%; border:2px solid rgba(15,23,42,.6)}
 .map-color-chip{display:inline-block;width:14px;height:14px;border-radius:50%;border:2px solid rgba(15,23,42,.6);vertical-align:middle}
 .map-upload{border:1px dashed rgba(148,163,184,.25); border-radius:12px; padding:16px; background:rgba(17,20,30,.6); display:flex; flex-direction:column; gap:12px}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2948,6 +2948,31 @@ button.menu-tab.active {
   font-size: 0.88rem;
 }
 
+.map-team-info .team-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.map-team-info .team-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.map-team-info .team-detail {
+  color: var(--muted-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.map-team-info .team-row.active .team-detail {
+  color: var(--text);
+}
+
 .map-color-chip {
   display: inline-block;
   width: 14px;


### PR DESCRIPTION
## Summary
- add a dedicated team info panel to the live map sidebar and render team or solo selections without runtime errors
- style the new team legend for both default and dark themes so selected teams stand out

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e157904f9c83319d723becfdc099f6