### PR TITLE
Add players directory display limit dropdown

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -3193,6 +3193,41 @@ pre {
   padding-left: 38px;
 }
 
+.module-select {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.module-select-control {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font: inherit;
+  padding: 8px 36px 8px 12px;
+  min-height: 36px;
+  cursor: pointer;
+}
+
+.module-select-control:focus {
+  border-color: rgba(244, 63, 94, 0.55);
+  box-shadow: 0 0 0 2px rgba(244, 63, 94, 0.25);
+}
+
+.module-select::after {
+  content: '▾';
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
 @media (max-width: 720px) {
   .module-search { flex-basis: 100%; max-width: none; }
 }


### PR DESCRIPTION
## Summary
- add a dropdown in the All Players module to choose how many records are shown (50–unlimited)
- persist the selection, update player counts, and slice the rendered list based on the chosen limit
- style the new control so it fits the module header actions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1583dad6883318dd314265c11e1ac