### PR TITLE
Handle oversized map uploads more gracefully

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -2464,8 +2464,12 @@
     if (contentType.includes('application/json')) data = await res.json();
     if (res.status === 401) throw new Error('unauthorized');
     if (!res.ok) {
-      const err = new Error(data?.error || 'api_error');
+      const fallbackCode = res.status === 413 ? 'image_too_large' : 'api_error';
+      const code = data?.error || fallbackCode;
+      const err = new Error(code);
       err.status = res.status;
+      if (data?.error) err.code = data.error;
+      else if (code !== 'api_error') err.code = code;
       throw err;
     }
     return data;


### PR DESCRIPTION
## Summary
- ensure the map upload workflow treats 413 responses as oversized uploads instead of retrying
- propagate payload-too-large responses through the API helper so the UI surfaces the correct error message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16d4ad33483319935762fabe7517c