### PR TITLE
Clarify self-hosted map upload limit adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ Set `RUSTMAPS_API_KEY=...` to provide a fallback RustMaps key (optional). Each p
 - The backend keeps a persistent WebSocket connection for every configured server and polls `status` on an interval.
 - Adjust the cadence with `MONITOR_INTERVAL_MS` (default `60000` ms) to balance responsiveness and RCON load.
 - Real-time health information and player counts are surfaced in the dashboard and streamed over Socket.IO to connected clients.
+
+## Raising map upload limits
+
+- The panel accepts custom map images up to **40 MB** by default (see `MAX_MAP_IMAGE_BYTES` in `backend/src/index.js`).
+- If you host the panel behind **nginx**, set `client_max_body_size 40M;` (or higher) in your site config and reload nginx.
+- For **Caddy**, configure `request_body { max_size 40MB }` (or higher) on the site handling the panel.
+- When reverse proxies enforce a lower cap you will see HTTP 413 errors during upload — raise the proxy limit first, then adjust `MAX_MAP_IMAGE_BYTES` if you need to allow even larger files.

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1210,7 +1210,8 @@
     missing_image: 'Choose an image before uploading.',
     invalid_image: 'The selected image could not be processed.',
     unsupported_image_type: 'Only PNG, JPEG, or WebP images are supported.',
-    image_too_large: 'The image is too large. Please upload a file under 40 MB.',
+    image_too_large:
+      'The server rejected the image as too large. The control panel accepts files up to 40 MB, but your hosting provider may enforce a smaller limit. Try uploading a smaller image or raise the upload cap in your host (for self-hosted installs, increase the request size allowed by your reverse proxy, e.g. "client_max_body_size" in nginx).',
     map_upload_failed: 'Uploading the map image failed. Please try again.',
     invalid_current_password: 'The current password you entered is incorrect.',
     password_mismatch: 'New password and confirmation do not match.'
@@ -2464,8 +2465,12 @@
     if (contentType.includes('application/json')) data = await res.json();
     if (res.status === 401) throw new Error('unauthorized');
     if (!res.ok) {
-      const err = new Error(data?.error || 'api_error');
+      const fallbackCode = res.status === 413 ? 'image_too_large' : 'api_error';
+      const code = data?.error || fallbackCode;
+      const err = new Error(code);
       err.status = res.status;
+      if (data?.error) err.code = data.error;
+      else if (code !== 'api_error') err.code = code;
       throw err;
     }
     return data;

--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1050,9 +1050,12 @@
           catch { payload = null; }
         }
         if (!res.ok) {
-          const err = new Error(payload?.error || 'map_upload_failed');
+          const fallbackCode = res.status === 413 ? 'image_too_large' : 'map_upload_failed';
+          const code = payload?.error || fallbackCode;
+          const err = new Error(code);
           err.status = res.status;
           if (payload?.error) err.code = payload.error;
+          else if (code !== 'map_upload_failed') err.code = code;
           throw err;
         }
         return payload;
@@ -1067,12 +1070,26 @@
           } catch (err) {
             if (!err) throw err;
             const status = typeof err.status === 'number' ? err.status : null;
-            const shouldFallback = !err.code && (status === 404 || status === 405 || status === 413);
+            if (status === 413 && !err.code) {
+              err.code = 'image_too_large';
+              throw err;
+            }
+            const shouldFallback = !err.code && (status === 404 || status === 405);
             if (!shouldFallback) throw err;
           }
         }
         const dataUrl = await readFileAsDataURL(file);
         return ctx.api(`/servers/${state.serverId}/map-image`, { image: dataUrl, mapKey }, 'POST');
+      }
+
+      function formatFileSize(bytes) {
+        if (!Number.isFinite(bytes)) return null;
+        if (bytes <= 0) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB'];
+        const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+        const value = bytes / Math.pow(1024, index);
+        const rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
+        return `${rounded} ${units[index]}`;
       }
 
       async function handleUpload() {
@@ -1086,8 +1103,15 @@
           return;
         }
         const MAX_MAP_IMAGE_BYTES = 40 * 1024 * 1024;
+        const attemptedBytes = typeof file.size === 'number' ? file.size : null;
         if (typeof file.size === 'number' && file.size > MAX_MAP_IMAGE_BYTES) {
-          showUploadNotice('The image is too large. Please upload a file under 40 MB.');
+          const attemptedLabel = attemptedBytes != null ? formatFileSize(attemptedBytes) : null;
+          const limitLabel = formatFileSize(MAX_MAP_IMAGE_BYTES);
+          showUploadNotice(
+            attemptedLabel
+              ? `The image is too large (${attemptedLabel}). Please upload a file under ${limitLabel}.`
+              : `The image is too large. Please upload a file under ${limitLabel}.`
+          );
           return;
         }
 
@@ -1122,8 +1146,17 @@
           if (code === 'missing_image') showUploadNotice('Choose an image before uploading.');
           else if (code === 'invalid_image') showUploadNotice('The selected image could not be processed.');
           else if (code === 'unsupported_image_type') showUploadNotice('Only PNG, JPEG, or WebP images are supported.');
-          else if (code === 'image_too_large') showUploadNotice('The image is too large. Please upload a file under 40 MB.');
-          else showUploadNotice(ctx.describeError?.(err) || 'Uploading the map image failed.');
+          else if (code === 'image_too_large') {
+            const attemptedLabel = attemptedBytes != null ? formatFileSize(attemptedBytes) : null;
+            const limitLabel = formatFileSize(MAX_MAP_IMAGE_BYTES);
+            const intro = attemptedLabel
+              ? `The server rejected the image as too large (${attemptedLabel}).`
+              : 'The server rejected the image as too large.';
+            showUploadNotice(
+              `${intro} The control panel accepts files up to ${limitLabel}, but your hosting provider may enforce a smaller limit. Try uploading a smaller image or raise the upload cap in your host (for self-hosted installs, increase the request size allowed by your reverse proxy, e.g. "client_max_body_size" in nginx).`,
+              'error'
+            );
+          } else showUploadNotice(ctx.describeError?.(err) || 'Uploading the map image failed.');
         } finally {
           uploadBtn.disabled = false;
           uploadBtn.textContent = previousLabel;


### PR DESCRIPTION
## Summary
- extend the oversize map upload error copy with guidance for raising reverse proxy limits when self-hosting
- document where to adjust the backend map size cap and how to increase limits in common reverse proxies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16d4ad33483319935762fabe7517c