### PR TITLE
Fix custom map metadata fetch conditions

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1442,7 +1442,8 @@
         const infoState = state.worldDetails;
         if (!infoState) return;
         const activeMeta = getActiveMapMeta();
-        if (hasMapImage(activeMeta)) return;
+        const isCustomMap = mapIsCustom(activeMeta, state.serverInfo);
+        if (hasMapImage(activeMeta) && !isCustomMap) return;
         const size = toNumber(infoState.size);
         const seed = toNumber(infoState.seed);
         if (!Number.isFinite(size) || size <= 0) return;
@@ -1508,9 +1509,8 @@
         if (typeof ctx.runCommand !== 'function') return;
         if (state.customMapChecksFrozen) return;
         const activeMeta = getActiveMapMeta();
-        if (hasMapImage(activeMeta)) return;
-        const needsSize = resolveWorldSize() == null;
-        const needsSeed = resolveWorldSeed() == null;
+        const needsSize = resolveWorldSize(activeMeta, state.serverInfo) == null;
+        const needsSeed = resolveWorldSeed(activeMeta, state.serverInfo) == null;
         if (!needsSize && !needsSeed) return;
         const infoState = state.worldDetails;
         if (!infoState) return;
@@ -2726,7 +2726,9 @@
           } else {
             renderAll();
           }
-          const shouldUpdateWorldDetails = !hasImage && !skipMapChecks;
+          const needsWorldSize = resolveWorldSize(activeMeta, state.serverInfo) == null;
+          const needsWorldSeed = resolveWorldSeed(activeMeta, state.serverInfo) == null;
+          const shouldUpdateWorldDetails = !skipMapChecks && (needsWorldSize || needsWorldSeed);
           if (shouldUpdateWorldDetails) {
             ensureWorldDetails('refresh')
               .catch((err) => ctx.log?.('World detail refresh failed: ' + (err?.message || err)));


### PR DESCRIPTION
## Summary
- continue requesting world size/seed when custom maps already have an uploaded image
- allow syncing world details for custom maps even after imagery is present
- refresh world-detail polling whenever metadata is still missing

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e1953341a48331acc8d8edc8c58a64