### PR TITLE
Improve live map world size parsing

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1195,9 +1195,24 @@
         const text = String(value).trim();
         if (!text) return null;
         const normalised = text.replace(/[_\s,]/g, '');
-        if (!normalised) return null;
-        const num = Number(normalised);
-        return Number.isFinite(num) ? num : null;
+        if (normalised) {
+          const direct = Number(normalised);
+          if (Number.isFinite(direct)) return direct;
+          const dimensionMatch = normalised.match(/^(-?\d+(?:\.\d+)?)[x×](-?\d+(?:\.\d+)?)/i);
+          if (dimensionMatch) {
+            const primary = Number(dimensionMatch[1]);
+            if (Number.isFinite(primary)) return primary;
+          }
+          const magnitudeMatch = normalised.match(/^(-?\d+(?:\.\d+)?)([kK])$/);
+          if (magnitudeMatch) {
+            const base = Number(magnitudeMatch[1]);
+            if (Number.isFinite(base)) return base * 1000;
+          }
+        }
+        const fallbackMatch = text.match(/-?\d+(?:\.\d+)?/);
+        if (!fallbackMatch) return null;
+        const numeric = Number(fallbackMatch[0]);
+        return Number.isFinite(numeric) ? numeric : null;
       }
 
       function worldDetailKey(size, seed) {


### PR DESCRIPTION
## Summary
- extend the live map number parser to handle dimension strings (e.g. 4000x4000)
- support shorthand world size values like 4k and extract digits from mixed strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2dbe297048331a6da4e2f90b7359e