### PR TITLE
Add pagination and server-side counts to player directory

### DIFF
--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -10,6 +10,7 @@ export default {
 };
 
 function createApi(dbh, dialect) {
+  const escapeLike = (value) => String(value).replace(/[\\%_]/g, (match) => `\\${match}`);
   return {
     dialect,
     async init() {
@@ -398,7 +399,57 @@ function createApi(dbh, dialect) {
       const placeholders = steamids.map(() => '?').join(',');
       return await dbh.all(`SELECT * FROM players WHERE steamid IN (${placeholders})`, steamids);
     },
-    async listPlayers({limit=100,offset=0}={}){ return await dbh.all('SELECT * FROM players ORDER BY updated_at DESC LIMIT ? OFFSET ?',[limit,offset]); },
+    async listPlayers({ limit = 100, offset = 0, search = '' } = {}) {
+      let sql = `
+        SELECT *
+        FROM players
+      `;
+      const params = [];
+      const term = typeof search === 'string' ? search.trim() : '';
+      if (term) {
+        const likeTerm = `%${escapeLike(term)}%`;
+        sql += `
+        WHERE steamid = ?
+          OR steamid LIKE ? ESCAPE '\\'
+          OR persona LIKE ? ESCAPE '\\'
+          OR profileurl LIKE ? ESCAPE '\\'
+          OR country LIKE ? ESCAPE '\\'
+        `;
+        params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
+      }
+      sql += '
+        ORDER BY updated_at DESC
+      ';
+      const limitNum = Number(limit);
+      const offsetNum = Number(offset);
+      if (Number.isFinite(limitNum) && limitNum > 0) {
+        sql += ' LIMIT ? OFFSET ?';
+        const safeLimit = Math.floor(limitNum);
+        const safeOffset = Number.isFinite(offsetNum) && offsetNum > 0 ? Math.floor(offsetNum) : 0;
+        params.push(safeLimit, safeOffset);
+      } else if (Number.isFinite(offsetNum) && offsetNum > 0) {
+        sql += ' LIMIT -1 OFFSET ?';
+        params.push(Math.floor(offsetNum));
+      }
+      return await dbh.all(sql, params);
+    },
+    async countPlayers({ search = '' } = {}) {
+      let sql = 'SELECT COUNT(*) as total FROM players';
+      const params = [];
+      const term = typeof search === 'string' ? search.trim() : '';
+      if (term) {
+        const likeTerm = `%${escapeLike(term)}%`;
+        sql += ` WHERE steamid = ?
+          OR steamid LIKE ? ESCAPE '\\'
+          OR persona LIKE ? ESCAPE '\\'
+          OR profileurl LIKE ? ESCAPE '\\'
+          OR country LIKE ? ESCAPE '\\'`;
+        params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
+      }
+      const row = await dbh.get(sql, params);
+      const numeric = Number(row?.total);
+      return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+    },
     async recordServerPlayer({ server_id, steamid, display_name = null, seen_at = null, ip = null, port = null }){
       const serverIdNum = Number(server_id);
       if (!Number.isFinite(serverIdNum)) return;
@@ -541,10 +592,12 @@ function createApi(dbh, dialect) {
 
       return await dbh.all(sql, params);
     },
-    async listServerPlayers(serverId,{limit=100,offset=0}={}){
+    async listServerPlayers(serverId, { limit = 100, offset = 0, search = '' } = {}) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
-      return await dbh.all(`
+      const limitNum = Number(limit);
+      const offsetNum = Number(offset);
+      let sql = `
         SELECT sp.server_id, sp.steamid, sp.display_name, sp.forced_display_name, sp.first_seen, sp.last_seen,
                 sp.last_ip, sp.last_port, sp.total_playtime_seconds,
                 p.persona, p.avatar, p.country, p.profileurl, p.vac_banned, p.game_bans,
@@ -552,16 +605,45 @@ function createApi(dbh, dialect) {
         FROM server_players sp
         LEFT JOIN players p ON p.steamid = sp.steamid
         WHERE sp.server_id=?
+      `;
+      const params = [serverIdNum];
+      const term = typeof search === 'string' ? search.trim() : '';
+      if (term) {
+        const likeTerm = `%${escapeLike(term)}%`;
+        sql += `
+        AND (
+          sp.steamid = ?
+          OR sp.steamid LIKE ? ESCAPE '\\'
+          OR sp.display_name LIKE ? ESCAPE '\\'
+          OR sp.forced_display_name LIKE ? ESCAPE '\\'
+          OR sp.last_ip LIKE ? ESCAPE '\\'
+          OR CAST(sp.last_port AS TEXT) LIKE ? ESCAPE '\\'
+          OR p.persona LIKE ? ESCAPE '\\'
+          OR p.profileurl LIKE ? ESCAPE '\\'
+          OR p.country LIKE ? ESCAPE '\\'
+        )
+      `;
+        params.push(term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm);
+      }
+      sql += '
         ORDER BY sp.last_seen DESC
-        LIMIT ? OFFSET ?
-      `,[serverIdNum,limit,offset]);
+      ';
+      if (Number.isFinite(limitNum) && limitNum > 0) {
+        const safeLimit = Math.floor(limitNum);
+        const safeOffset = Number.isFinite(offsetNum) && offsetNum > 0 ? Math.floor(offsetNum) : 0;
+        sql += ' LIMIT ? OFFSET ?';
+        params.push(safeLimit, safeOffset);
+      } else if (Number.isFinite(offsetNum) && offsetNum > 0) {
+        sql += ' LIMIT -1 OFFSET ?';
+        params.push(Math.floor(offsetNum));
+      }
+      return await dbh.all(sql, params);
     },
     async searchServerPlayers(serverId, query, { limit = 10 } = {}) {
       const serverIdNum = Number(serverId);
       if (!Number.isFinite(serverIdNum)) return [];
       const term = typeof query === 'string' ? query.trim() : '';
       if (!term) return [];
-      const escapeLike = (value) => String(value).replace(/[\\%_]/g, (m) => `\\${m}`);
       const likeTerm = `%${escapeLike(term)}%`;
       const limitValue = Number(limit);
       const limitNum = Number.isFinite(limitValue) && limitValue > 0 ? Math.min(Math.floor(limitValue), 25) : 10;
@@ -575,13 +657,48 @@ function createApi(dbh, dialect) {
         WHERE sp.server_id=?
           AND (
             sp.steamid = ? OR
+            sp.steamid LIKE ? ESCAPE '\\' OR
             sp.display_name LIKE ? ESCAPE '\\' OR
             sp.forced_display_name LIKE ? ESCAPE '\\' OR
-            p.persona LIKE ? ESCAPE '\\'
+            sp.last_ip LIKE ? ESCAPE '\\' OR
+            CAST(sp.last_port AS TEXT) LIKE ? ESCAPE '\\' OR
+            p.persona LIKE ? ESCAPE '\\' OR
+            p.profileurl LIKE ? ESCAPE '\\' OR
+            p.country LIKE ? ESCAPE '\\'
           )
         ORDER BY sp.last_seen DESC
         LIMIT ?
-      `, [serverIdNum, term, likeTerm, likeTerm, likeTerm, limitNum]);
+      `, [serverIdNum, term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, limitNum]);
+    },
+    async countServerPlayers(serverId, { search = '' } = {}) {
+      const serverIdNum = Number(serverId);
+      if (!Number.isFinite(serverIdNum)) return 0;
+      let sql = `
+        SELECT COUNT(*) as total
+        FROM server_players sp
+        LEFT JOIN players p ON p.steamid = sp.steamid
+        WHERE sp.server_id=?
+      `;
+      const params = [serverIdNum];
+      const term = typeof search === 'string' ? search.trim() : '';
+      if (term) {
+        const likeTerm = `%${escapeLike(term)}%`;
+        sql += ` AND (
+          sp.steamid = ?
+          OR sp.steamid LIKE ? ESCAPE '\\'
+          OR sp.display_name LIKE ? ESCAPE '\\'
+          OR sp.forced_display_name LIKE ? ESCAPE '\\'
+          OR sp.last_ip LIKE ? ESCAPE '\\'
+          OR CAST(sp.last_port AS TEXT) LIKE ? ESCAPE '\\'
+          OR p.persona LIKE ? ESCAPE '\\'
+          OR p.profileurl LIKE ? ESCAPE '\\'
+          OR p.country LIKE ? ESCAPE '\\'
+        )`;
+        params.push(term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm);
+      }
+      const row = await dbh.get(sql, params);
+      const numeric = Number(row?.total);
+      return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
     },
     async getServerPlayer(serverId, steamid) {
       const serverIdNum = Number(serverId);

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1674,6 +1674,8 @@ button.menu-tab.active {
 }
 
 .module-message.hidden { display: none; }
+.module-pagination { display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; margin-top: 16px; }
+.module-pagination-info { font-size: 0.85rem; color: var(--muted); }
 
 .live-players-list {
   display: grid;


### PR DESCRIPTION
## Summary
- expose pagination metadata from the players APIs, including optional search filters and unlimited limits
- extend both database dialects with filtered count helpers and LIKE-based search support for player listings
- default the All Players module to 200 rows per page, fetch pages from the server, and add pagination controls with new styling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e2dbf72004833199dfaae995c68be0