### PR TITLE
Fix multiline sqlite query strings

### DIFF
--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -417,9 +417,9 @@ function createApi(dbh, dialect) {
         `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY updated_at DESC
-      ';
+      `;
       const limitNum = Number(limit);
       const offsetNum = Number(offset);
       if (Number.isFinite(limitNum) && limitNum > 0) {
@@ -439,11 +439,13 @@ function createApi(dbh, dialect) {
       const term = typeof search === 'string' ? search.trim() : '';
       if (term) {
         const likeTerm = `%${escapeLike(term)}%`;
-        sql += ` WHERE steamid = ?
+        sql += `
+        WHERE steamid = ?
           OR steamid LIKE ? ESCAPE '\\'
           OR persona LIKE ? ESCAPE '\\'
           OR profileurl LIKE ? ESCAPE '\\'
-          OR country LIKE ? ESCAPE '\\'`;
+          OR country LIKE ? ESCAPE '\\'
+        `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
       const row = await dbh.get(sql, params);
@@ -625,9 +627,9 @@ function createApi(dbh, dialect) {
       `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY sp.last_seen DESC
-      ';
+      `;
       if (Number.isFinite(limitNum) && limitNum > 0) {
         const safeLimit = Math.floor(limitNum);
         const safeOffset = Number.isFinite(offsetNum) && offsetNum > 0 ? Math.floor(offsetNum) : 0;


### PR DESCRIPTION
## Summary
- convert multiline SQL string concatenations in sqlite.js to template literals
- ensure count and list queries build valid SQL across Node.js versions

## Testing
- node --check src/db/sqlite.js

------
https://chatgpt.com/codex/tasks/task_e_68e2e8fc90fc8331b3d071872f20abd4