### PR TITLE
Fix invalid multiline SQL string literals in player queries

### DIFF
--- a/backend/src/db/mysql.js
+++ b/backend/src/db/mysql.js
@@ -337,9 +337,9 @@ function createApi(pool, dialect) {
         `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY updated_at DESC
-      ';
+      `;
       const limitNum = Number(limit);
       const offsetNum = Number(offset);
       if (Number.isFinite(limitNum) && limitNum > 0) {
@@ -359,11 +359,13 @@ function createApi(pool, dialect) {
       const term = typeof search === 'string' ? search.trim() : '';
       if (term) {
         const likeTerm = `%${escapeLike(term)}%`;
-        sql += ` WHERE steamid = ?
+        sql += `
+        WHERE steamid = ?
           OR steamid LIKE ? ESCAPE '\\'
           OR persona LIKE ? ESCAPE '\\'
           OR profileurl LIKE ? ESCAPE '\\'
-          OR country LIKE ? ESCAPE '\\'`;
+          OR country LIKE ? ESCAPE '\\'
+      `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
       const rows = await exec(sql, params);
@@ -548,9 +550,9 @@ function createApi(pool, dialect) {
       `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY sp.last_seen DESC
-      ';
+      `;
       if (Number.isFinite(limitNum) && limitNum > 0) {
         const safeLimit = Math.floor(limitNum);
         const safeOffset = Number.isFinite(offsetNum) && offsetNum > 0 ? Math.floor(offsetNum) : 0;

--- a/backend/src/db/sqlite.js
+++ b/backend/src/db/sqlite.js
@@ -417,9 +417,9 @@ function createApi(dbh, dialect) {
         `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY updated_at DESC
-      ';
+      `;
       const limitNum = Number(limit);
       const offsetNum = Number(offset);
       if (Number.isFinite(limitNum) && limitNum > 0) {
@@ -439,11 +439,13 @@ function createApi(dbh, dialect) {
       const term = typeof search === 'string' ? search.trim() : '';
       if (term) {
         const likeTerm = `%${escapeLike(term)}%`;
-        sql += ` WHERE steamid = ?
+        sql += `
+        WHERE steamid = ?
           OR steamid LIKE ? ESCAPE '\\'
           OR persona LIKE ? ESCAPE '\\'
           OR profileurl LIKE ? ESCAPE '\\'
-          OR country LIKE ? ESCAPE '\\'`;
+          OR country LIKE ? ESCAPE '\\'
+      `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm);
       }
       const row = await dbh.get(sql, params);
@@ -625,9 +627,9 @@ function createApi(dbh, dialect) {
       `;
         params.push(term, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm, likeTerm);
       }
-      sql += '
+      sql += `
         ORDER BY sp.last_seen DESC
-      ';
+      `;
       if (Number.isFinite(limitNum) && limitNum > 0) {
         const safeLimit = Math.floor(limitNum);
         const safeOffset = Number.isFinite(offsetNum) && offsetNum > 0 ? Math.floor(offsetNum) : 0;


### PR DESCRIPTION
## Summary
- replace problematic multiline string concatenations in the sqlite and mysql database adapters with template literals
- ensure player listing and count queries append their ORDER BY clauses without triggering syntax errors

## Testing
- npm start
- curl http://127.0.0.1:8787/api/public-config
- curl -X POST http://127.0.0.1:8787/api/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin123"}'
- curl http://127.0.0.1:8787/api/me -H "Authorization: Bearer <token>"


------
https://chatgpt.com/codex/tasks/task_e_68e3409d99bc83318538d8d5b72d6374