### PR TITLE
Clarify player search input metadata

### DIFF
--- a/frontend/assets/modules/live-players.js
+++ b/frontend/assets/modules/live-players.js
@@ -124,7 +124,11 @@
         searchInput = document.createElement('input');
         searchInput.type = 'search';
         searchInput.placeholder = 'Search players, Steam ID or IP';
-        searchInput.autocomplete = 'off';
+        searchInput.autocomplete = 'search';
+        searchInput.name = 'players-search';
+        searchInput.setAttribute('inputmode', 'search');
+        searchInput.setAttribute('role', 'searchbox');
+        searchInput.setAttribute('autocomplete', 'search');
         searchInput.setAttribute('aria-label', 'Search connected players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -99,7 +99,11 @@
         searchInput = document.createElement('input');
         searchInput.type = 'search';
         searchInput.placeholder = 'Search players, Steam ID or IP';
-        searchInput.autocomplete = 'off';
+        searchInput.autocomplete = 'search';
+        searchInput.name = 'players-search';
+        searchInput.setAttribute('inputmode', 'search');
+        searchInput.setAttribute('role', 'searchbox');
+        searchInput.setAttribute('autocomplete', 'search');
         searchInput.setAttribute('aria-label', 'Search players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);


### PR DESCRIPTION
## Summary
- annotate the player search inputs with search-specific metadata so password managers no longer mis-detect them as login fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e34374215083319920db7139993dd4