### PR TITLE
Fix chat rendering initialization order

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -38,6 +38,23 @@
   const btnSend = $('#btnSend');
   const cmdInput = $('#cmd');
   const cmdInputDefaultPlaceholder = cmdInput?.getAttribute('placeholder') || '';
+
+  const state = {
+    API: '',
+    TOKEN: localStorage.getItem('token') || '',
+    currentUser: null,
+    currentServerId: null,
+    serverItems: new Map(),
+    allowRegistration: false,
+    statusTimer: null,
+    settings: {},
+    activePanel: 'dashboard',
+    activeTeamId: null,
+    activeTeamName: null,
+    teams: [],
+    roles: [],
+    roleTemplates: { serverCapabilities: [], globalPermissions: [] }
+  };
   const loginUsername = $('#username');
   const loginPassword = $('#password');
   const btnLogin = $('#btnLogin');
@@ -515,23 +532,6 @@
       name: 'Manage roles',
       description: 'Create, edit, and delete roles or adjust their permissions.'
     }
-  };
-
-  const state = {
-    API: '',
-    TOKEN: localStorage.getItem('token') || '',
-    currentUser: null,
-    currentServerId: null,
-    serverItems: new Map(),
-    allowRegistration: false,
-    statusTimer: null,
-    settings: {},
-    activePanel: 'dashboard',
-    activeTeamId: null,
-    activeTeamName: null,
-    teams: [],
-    roles: [],
-    roleTemplates: { serverCapabilities: [], globalPermissions: [] }
   };
 
   let socket = null;


### PR DESCRIPTION
## Summary
- move the global state initialization to the top of the frontend bundle
- prevent chat rendering from executing before the state object is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35288d0f48331a83e8d7473599e59