### PR TITLE
Fix live map player parsing and world size priorities

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1400,17 +1400,7 @@
           && meta
           && mapIsCustom(meta, info)
           && hasMapImage(meta);
-        const metadataMatchesImage = hasImageSize && Number.isFinite(metadataSize)
-          ? Math.abs(metadataSize - imageSize) <= 5
-          : false;
-
         if (preferImageForCustomMap) {
-          state.estimatedWorldSize = null;
-          state.estimatedWorldSizeSource = null;
-          return imageSize;
-        }
-
-        if (hasImageSize && !metadataMatchesImage) {
           state.estimatedWorldSize = null;
           state.estimatedWorldSizeSource = null;
           return imageSize;


### PR DESCRIPTION
## Summary
- add heuristics to pick real player arrays from RCON payloads, ignore sample entries, and retain owner/position data when parsing
- keep legacy parsing fallback but enrich player objects with nested owner steam IDs for live map updates
- prefer server-reported world sizes for procedural maps while still using image-derived sizes for custom map imagery

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e35a3cf300833197c47955381d4421