### PR TITLE
Throttle manual live-map enrichment and add position fallback

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1470,6 +1470,7 @@
     rustmaps_image_error: 'RustMaps returned an invalid map image.',
     custom_level_url: 'This server is using a custom map. Configure a Facepunch level URL to enable the live map.',
     live_map_failed: 'Unable to load the live map right now.',
+    manual_refresh_cooldown: 'Manual live map refresh is cooling down. Try again in a few seconds.',
     playerlist_failed: 'The server did not return a live player list.',
     missing_command: 'Provide a command before sending.',
     no_server_selected: 'Select a server before sending commands.',


### PR DESCRIPTION
## Summary
- add cached manual enrichment helpers that query `teaminfo` and `printpos` only when player lists lack team ids or coordinates
- throttle manual lookups behind a 20s cooldown and reuse cached data in the live map route when manual mode is needed
- surface a frontend error message when the backend rejects a refresh during the manual cooldown window

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e36a457ac48331a9df946203707ff0