### PR TITLE
Animate live map player markers

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -380,6 +380,7 @@
         mapCanvas,
         mapImage,
         overlay,
+        markers: new Map(),
         message,
         summary,
         teamInfo,
@@ -463,6 +464,27 @@
 
       function getActiveViewports() {
         return [mainViewport];
+      }
+
+      function getViewportMarkerStore(viewport) {
+        if (!viewport) return null;
+        if (!viewport.markers || !(viewport.markers instanceof Map)) {
+          viewport.markers = new Map();
+        }
+        return viewport.markers;
+      }
+
+      function clearViewportMarkers(viewport) {
+        if (!viewport || !viewport.overlay) return;
+        viewport.overlay.innerHTML = '';
+        const store = getViewportMarkerStore(viewport);
+        store?.clear?.();
+      }
+
+      function clearAllViewportMarkers() {
+        for (const viewport of getActiveViewports()) {
+          clearViewportMarkers(viewport);
+        }
       }
 
       function clampMapOffsets() {
@@ -2098,30 +2120,75 @@
         }
       }
 
+      function handleMarkerClick(event) {
+        if (!event) return;
+        event.stopPropagation();
+        const marker = event.currentTarget;
+        const steamId = marker?.dataset?.steamid;
+        if (!steamId) return;
+        const player = state.players.find((p) => resolveSteamId(p) === steamId);
+        if (!player) return;
+        selectPlayer(player, { suppressPanel: true, showPopup: true });
+      }
+
       function renderMarkersInViewport(viewport) {
         if (!viewport || !viewport.overlay) return;
-        viewport.overlay.innerHTML = '';
-        if (!mapReady()) return;
+        const overlayEl = viewport.overlay;
+        const markerStore = getViewportMarkerStore(viewport);
+
+        if (!mapReady()) {
+          if (markerStore.size || overlayEl.childElementCount) {
+            clearViewportMarkers(viewport);
+          }
+          return;
+        }
+
         const axis = resolveHorizontalAxis();
+        const staleIds = new Set(markerStore.keys());
+        const selectionEngaged = selectionActive();
+
         for (const player of state.players) {
+          const steamId = resolveSteamId(player);
+          if (!steamId) continue;
           const position = projectPosition(player.position, axis);
-          if (!position) continue;
-          const marker = viewport.doc.createElement('div');
-          marker.className = 'map-marker';
-          marker.style.backgroundColor = colorForPlayer(player);
+          if (!position) {
+            const existing = markerStore.get(steamId);
+            if (existing) {
+              existing.remove();
+              markerStore.delete(steamId);
+              staleIds.delete(steamId);
+            }
+            continue;
+          }
+
+          let marker = markerStore.get(steamId);
+          if (!marker) {
+            marker = viewport.doc.createElement('div');
+            marker.className = 'map-marker';
+            marker.dataset.steamid = steamId;
+            marker.addEventListener('click', handleMarkerClick);
+            marker.style.left = position.left + '%';
+            marker.style.top = position.top + '%';
+            marker.style.backgroundColor = colorForPlayer(player);
+            marker.title = player.displayName || player.persona || steamId;
+            overlayEl.appendChild(marker);
+            markerStore.set(steamId, marker);
+          }
+
           marker.style.left = position.left + '%';
           marker.style.top = position.top + '%';
-          const steamId = resolveSteamId(player);
+          marker.style.backgroundColor = colorForPlayer(player);
           marker.title = player.displayName || player.persona || steamId;
-          marker.dataset.steamid = steamId;
           const focused = isPlayerFocused(player);
-          if (selectionActive() && !focused) marker.classList.add('dimmed');
-          if (focused) marker.classList.add('active');
-          marker.addEventListener('click', (e) => {
-            e.stopPropagation();
-            selectPlayer(player, { suppressPanel: true, showPopup: true });
-          });
-          viewport.overlay.appendChild(marker);
+          marker.classList.toggle('active', focused);
+          marker.classList.toggle('dimmed', selectionEngaged && !focused);
+          staleIds.delete(steamId);
+        }
+
+        for (const steamId of staleIds) {
+          const marker = markerStore.get(steamId);
+          if (marker) marker.remove();
+          markerStore.delete(steamId);
         }
       }
 
@@ -3035,7 +3102,7 @@
           state.worldDetails.syncing = false;
           state.worldDetails.syncError = null;
         }
-        overlay.innerHTML = '';
+        clearAllViewportMarkers();
         cancelMapImageRequest();
         clearMapImage();
         updateConfigPanel();
@@ -3090,7 +3157,7 @@
             state.worldDetails.syncError = null;
           }
           clearSelection();
-          overlay.innerHTML = '';
+          clearAllViewportMarkers();
           cancelMapImageRequest();
           clearMapImage();
           renderPlayerList();
@@ -3137,7 +3204,7 @@
           state.worldDetails.syncError = null;
         }
         clearSelection();
-        overlay.innerHTML = '';
+        clearAllViewportMarkers();
         cancelMapImageRequest();
         clearMapImage();
         renderPlayerList();

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2484,6 +2484,8 @@ button.chat-filter-btn:focus-visible {
   border: clamp(1px, calc(2px * var(--marker-scale)), 2px) solid rgba(248, 250, 252, 0.75);
   box-shadow: 0 6px clamp(10px, calc(18px * var(--marker-scale)), 18px) rgba(15, 23, 42, 0.22);
   transform: translate(-50%, -50%);
+  transition: left 0.45s ease, top 0.45s ease;
+  will-change: left, top;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- reuse persistent marker elements so player dots move smoothly across the live map
- clear cached markers when changing servers or sessions to avoid stale positions
- add CSS transitions to animate marker position updates

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3a24252c883319d0378ac3919d715