### PR TITLE
Adjust live map polling by player data source

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4517,8 +4517,11 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       return res.status(502).json({ error: 'playerlist_failed' });
     }
     let players = parsePlayerListMessage(playerPayload);
+    const playerCount = Array.isArray(players) ? players.length : 0;
     const playerListHasTeamData = players.some((p) => Number(p?.teamId) > 0);
     const playerListHasPositionData = players.some((p) => hasValidPosition(p?.position));
+    const teamDataSource = playerListHasTeamData || playerCount === 0 ? 'playerlist' : 'teaminfo';
+    const positionDataSource = playerListHasPositionData || playerCount === 0 ? 'playerlist' : 'printpos';
 
     const teamPrep = await enrichPlayersWithTeamInfo(id, server, players, {
       logger,
@@ -4900,7 +4903,11 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       map: mapPayload,
       info,
       status,                    // <-- new
-      fetchedAt: new Date().toISOString()
+      fetchedAt: new Date().toISOString(),
+      playerDataSources: {
+        positions: positionDataSource,
+        teams: teamDataSource
+      }
     };
 
     res.json(responsePayload);


### PR DESCRIPTION
## Summary
- add player data source metadata to live map responses so the UI knows whether data came from playerlist or manual lookups
- slow live map polling to 30 seconds whenever manual position or team lookups are required while keeping 5-second polls for pure playerlist data
- persist the detected data source in the map module state and reset it when the workspace tears down

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3a4e0e1d88331abde9f3c641d0265