### PR TITLE
Animate live map markers over five seconds

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2484,6 +2484,8 @@ button.chat-filter-btn:focus-visible {
   border: clamp(1px, calc(2px * var(--marker-scale)), 2px) solid rgba(248, 250, 252, 0.75);
   box-shadow: 0 6px clamp(10px, calc(18px * var(--marker-scale)), 18px) rgba(15, 23, 42, 0.22);
   transform: translate(-50%, -50%);
+  transition: none;
+  will-change: left, top;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- animate marker position updates over a fixed five-second duration using requestAnimationFrame
- cancel any in-flight marker animations when clearing overlays or removing stale markers
- remove CSS transitions so manual updates fully control marker movement

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3a24252c883319d0378ac3919d715