### PR TITLE
Handle solo teaminfo responses

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -695,6 +695,7 @@ const chatCleanupSchedule = new Map();
 
 const steamProfileCache = new Map();
 const TEAM_INFO_CACHE_TTL = 30 * 1000;
+const TEAM_INFO_ERROR_RETRY_INTERVAL_MS = 10 * 1000;
 const TEAM_INFO_COMMAND_TIMEOUT_MS = 5000;
 const POSITION_CACHE_TTL = 30 * 1000;
 const POSITION_COMMAND_TIMEOUT_MS = 5000;
@@ -2380,7 +2381,7 @@ function extractTeamInfoFromNode(node, requestedSteamId) {
     health: Number.isFinite(member.health) ? Math.round(member.health) : null
   }));
 
-  const hasTeam = Number.isFinite(teamId) && teamId > 0 && members.length > 0;
+  const hasTeam = Number.isFinite(teamId) && teamId > 0;
 
   return {
     teamId: Number.isFinite(teamId) ? Math.trunc(teamId) : 0,
@@ -2514,7 +2515,7 @@ function extractTeamInfoFromText(text, requestedSteamId) {
     health: null
   }));
 
-  const hasTeam = Number.isFinite(teamId) && teamId > 0 && members.length > 0;
+  const hasTeam = Number.isFinite(teamId) && teamId > 0;
 
   return {
     teamId: Number.isFinite(teamId) ? Math.trunc(teamId) : 0,
@@ -2749,7 +2750,7 @@ function cacheTeamInfoForServer(serverId, info, now = Date.now()) {
   if (leaderSteamId) pushMember({ steamId: leaderSteamId });
   if (ownerSteamId) pushMember({ steamId: ownerSteamId });
 
-  const hasTeam = Number.isFinite(teamId) && teamId > 0 && members.length > 0;
+  const hasTeam = Number.isFinite(teamId) && teamId > 0;
 
   const cacheEntry = {
     teamId: hasTeam ? teamId : 0,
@@ -2966,7 +2967,10 @@ async function enrichPlayersWithTeamInfo(
     for (const [steamId, player] of playerMap.entries()) {
       if (Number(player.teamId) > 0) continue;
       const cached = lookupCachedTeamInfoForPlayer(numeric, steamId, now);
-      if (cached) continue;
+      if (cached) {
+        if (!cached.error) continue;
+        if (now - cached.fetchedAt < TEAM_INFO_ERROR_RETRY_INTERVAL_MS) continue;
+      }
       pending.push(steamId);
     }
   } else {
@@ -2987,10 +2991,32 @@ async function enrichPlayersWithTeamInfo(
       });
       lookupsPerformed = true;
       const info = parseTeamInfoMessage(reply, steamId);
-      if (info) {
+      if (info?.hasTeam) {
         cacheTeamInfoForServer(numeric, info, Date.now());
         if (logger?.debug) {
           logger.debug('teaminfo resolved', { steamId, teamId: info.teamId || 0, hasTeam: info.hasTeam });
+        }
+      } else if (info) {
+        const timestamp = Date.now();
+        const targets = new Set();
+        if (info.requestedSteamId && STEAM_ID_REGEX.test(info.requestedSteamId)) {
+          targets.add(info.requestedSteamId);
+        }
+        if (Array.isArray(info.members)) {
+          for (const member of info.members) {
+            if (member?.steamId && STEAM_ID_REGEX.test(member.steamId)) {
+              targets.add(member.steamId);
+            }
+          }
+        }
+        if (targets.size === 0 && STEAM_ID_REGEX.test(steamId)) {
+          targets.add(steamId);
+        }
+        for (const target of targets) {
+          cacheTeamInfoMiss(numeric, target, timestamp);
+        }
+        if (logger?.debug) {
+          logger.debug('teaminfo reported no team', { steamId, requestedSteamId: info.requestedSteamId, memberCount: info.members?.length || 0 });
         }
       } else {
         cacheTeamInfoMiss(numeric, steamId, Date.now());
@@ -4531,14 +4557,16 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
     });
     players = positionPrep.players;
 
-    const needsManualTeamLookup = !playerListHasTeamData && teamPrep.pending.length > 0;
-    const needsManualPositionLookup = !playerListHasPositionData && positionPrep.pending.length > 0;
+    const needsManualTeamLookup = teamPrep.pending.length > 0;
+    const needsManualPositionLookup = positionPrep.pending.length > 0;
+    const requiresManualCooldown = (!playerListHasTeamData && needsManualTeamLookup)
+      || (!playerListHasPositionData && needsManualPositionLookup);
 
     if (!(needsManualTeamLookup || needsManualPositionLookup)) {
       clearManualRefreshState(id);
     }
 
-    if (needsManualTeamLookup || needsManualPositionLookup) {
+    if (requiresManualCooldown) {
       const cooldown = manualRefreshCooldown(id);
       if (cooldown.coolingDown) {
         const retryAfterSeconds = Math.max(1, Math.ceil(cooldown.retryAfterMs / 1000));


### PR DESCRIPTION
## Summary
- avoid caching teaminfo lookups as successes when the response reports no team
- requeue failed team lookups after a short cooldown so players can be updated once they join a team

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3a5c16f28833187bf79f2403f013a