### PR TITLE
Fix chat channel mapping and streamline chat message display

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -242,8 +242,21 @@
   }
 
   function normalizeChatChannel(value) {
-    const text = typeof value === 'string' ? value.trim().toLowerCase() : '';
-    return text === 'team' ? 'team' : 'global';
+    if (typeof value === 'number') {
+      return value === 1 ? 'team' : 'global';
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return 'global';
+      const numeric = Number(trimmed);
+      if (Number.isFinite(numeric)) return numeric === 1 ? 'team' : 'global';
+      const lower = trimmed.toLowerCase();
+      if (lower === 'team') return 'team';
+      if (lower === 'global') return 'global';
+      if (lower === '1') return 'team';
+      if (lower === '0') return 'global';
+    }
+    return 'global';
   }
 
   function normalizeChatColor(value) {
@@ -270,14 +283,6 @@
       return `rgb(${numeric[0]}, ${numeric[1]}, ${numeric[2]})`;
     }
     return null;
-  }
-
-  function formatChatTime(value) {
-    const text = pickString(value);
-    if (!text) return '';
-    const date = new Date(text);
-    if (Number.isNaN(date.valueOf())) return text;
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
   }
 
   function messageSignature(entry) {
@@ -413,22 +418,17 @@
       li.dataset.channel = entry.channel;
       const header = document.createElement('div');
       header.className = 'chat-entry-header';
-      const timeEl = document.createElement('time');
-      timeEl.className = 'chat-entry-time';
-      timeEl.dateTime = entry.createdAt;
-      timeEl.textContent = formatChatTime(entry.createdAt);
-      const channelEl = document.createElement('span');
-      channelEl.className = 'chat-entry-channel';
-      channelEl.textContent = entry.channel === 'team' ? 'Team' : 'Global';
       const nameEl = document.createElement('span');
       nameEl.className = 'chat-entry-name';
-      const displayName = entry.username || entry.steamId || 'Unknown';
-      nameEl.textContent = displayName;
+      nameEl.textContent = entry.username || entry.steamId || 'Unknown';
       nameEl.style.color = entry.color || '';
-      if (entry.steamId && entry.username && entry.username !== entry.steamId) {
-        nameEl.title = entry.steamId;
+      header.appendChild(nameEl);
+      if (entry.steamId) {
+        const idEl = document.createElement('span');
+        idEl.className = 'chat-entry-id';
+        idEl.textContent = entry.steamId;
+        header.appendChild(idEl);
       }
-      header.append(timeEl, channelEl, nameEl);
       const messageEl = document.createElement('p');
       messageEl.className = 'chat-entry-message';
       messageEl.textContent = entry.message;

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1445,37 +1445,23 @@ button.menu-tab.active {
 
 .chat-entry-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 10px;
   flex-wrap: wrap;
   font-size: 0.85rem;
   color: var(--muted-strong);
 }
 
-.chat-entry-time {
-  font-variant-numeric: tabular-nums;
-  color: var(--muted);
-}
-
-.chat-entry-channel {
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: rgba(244, 63, 94, 0.18);
-  color: var(--accent-strong);
-  font-weight: 600;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.chat-entry.team .chat-entry-channel {
-  background: rgba(59, 130, 246, 0.22);
-  color: rgba(191, 219, 254, 0.95);
-}
-
 .chat-entry-name {
   font-weight: 600;
   color: var(--text);
+}
+
+.chat-entry-id {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  word-break: break-all;
 }
 
 .chat-entry-message {


### PR DESCRIPTION
## Summary
- map numeric chat channel values to global and team scopes
- show only username, player ID, and message in the chat list with updated styling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b3e986148331b380c078bf57548a