### PR TITLE
Disable player search autocomplete metadata

### DIFF
--- a/frontend/assets/modules/live-players.js
+++ b/frontend/assets/modules/live-players.js
@@ -124,11 +124,10 @@
         searchInput = document.createElement('input');
         searchInput.type = 'search';
         searchInput.placeholder = 'Search players, Steam ID or IP';
-        searchInput.autocomplete = 'search';
-        searchInput.name = 'players-search';
+        searchInput.autocomplete = 'off';
         searchInput.setAttribute('inputmode', 'search');
         searchInput.setAttribute('role', 'searchbox');
-        searchInput.setAttribute('autocomplete', 'search');
+        searchInput.setAttribute('autocomplete', 'off');
         searchInput.setAttribute('aria-label', 'Search connected players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);

--- a/frontend/assets/modules/players.js
+++ b/frontend/assets/modules/players.js
@@ -99,11 +99,10 @@
         searchInput = document.createElement('input');
         searchInput.type = 'search';
         searchInput.placeholder = 'Search players, Steam ID or IP';
-        searchInput.autocomplete = 'search';
-        searchInput.name = 'players-search';
+        searchInput.autocomplete = 'off';
         searchInput.setAttribute('inputmode', 'search');
         searchInput.setAttribute('role', 'searchbox');
-        searchInput.setAttribute('autocomplete', 'search');
+        searchInput.setAttribute('autocomplete', 'off');
         searchInput.setAttribute('aria-label', 'Search players by name, Steam ID, or IP address');
         searchWrap.appendChild(searchInput);
         ctx.actions.appendChild(searchWrap);


### PR DESCRIPTION
## Summary
- disable browser autocomplete on player search inputs to avoid password manager suggestions
- remove unnecessary name metadata from player search inputs across players modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b893af048331b6c018d30f9167cd