### PR TITLE
Make live map sizing responsive

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -209,9 +209,9 @@ main.grid{
 .map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
 .map-layout{display:flex; flex-direction:column; gap:18px}
 .live-map-card .map-layout{max-width:960px;margin:0 auto}
-.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7); aspect-ratio:1/1}
-.map-view.map-view-has-message{aspect-ratio:auto}
-.live-map-card .map-view{min-height:clamp(260px,45vh,420px)}
+.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7); width:100%; min-height:clamp(260px,45vh,420px)}
+.map-view.map-view-dynamic{--map-size:clamp(260px,45vh,420px); width:min(100%, var(--map-size)); height:var(--map-size); min-height:0; max-height:none; aspect-ratio:1/1}
+.map-view.map-view-has-message{width:100%; min-height:clamp(240px,48vh,420px); height:auto}
 .map-view img{display:block; width:100%; height:auto}
 .map-placeholder{position:absolute; inset:0; display:none; align-items:center; justify-content:center; flex-direction:column; gap:18px; padding:32px 24px; text-align:center; background:rgba(15,23,42,.86); color:var(--muted); font-size:.96rem; line-height:1.5; z-index:2; overflow:auto}
 .map-overlay{position:absolute; inset:0; pointer-events:none; --marker-scale:1; z-index:3}

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2342,13 +2342,24 @@ button.chat-filter-btn:focus-visible {
   border: 1px solid rgba(148, 163, 184, 0.24);
   background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(30, 41, 59, 0.86) 100%);
   box-shadow: 0 32px 68px rgba(8, 13, 30, 0.55);
+  width: 100%;
   min-height: clamp(320px, 44vh, 520px);
-  aspect-ratio: 1 / 1;
   transition: background 0.28s ease, border-color 0.28s ease, box-shadow 0.28s ease;
 }
 
+.map-view.map-view-dynamic {
+  --map-size: clamp(320px, 44vh, 520px);
+  width: min(100%, var(--map-size));
+  height: var(--map-size);
+  min-height: 0;
+  max-height: none;
+  aspect-ratio: 1 / 1;
+}
+
 .map-view.map-view-has-message {
-  aspect-ratio: auto;
+  width: 100%;
+  min-height: clamp(280px, 48vh, 520px);
+  height: auto;
 }
 
 .map-view::before {


### PR DESCRIPTION
## Summary
- add responsive sizing logic to the live map module so it adapts to the available viewport space
- update light and dark theme styles to support the new dynamic map sizing behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b85a5f748331ab6726d88dc1ef97