### PR TITLE
Allow live map markers to render without imagery

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -1199,10 +1199,16 @@
       }
 
       function mapReady() {
-        const meta = getActiveMapMeta();
-        if (!meta || !hasMapImage(meta)) return false;
         const size = resolveWorldSize();
-        return Number.isFinite(size) && size > 0;
+        if (!Number.isFinite(size) || size <= 0) return false;
+
+        const meta = getActiveMapMeta();
+        const imageLoaded = hasMapImage(meta)
+          || !!(mapImageSource || (mapImage && mapImage.currentSrc));
+        if (imageLoaded) return true;
+
+        const samples = collectPlayerPositions();
+        return Array.isArray(samples) && samples.length > 0;
       }
 
       function updateUploadSection() {


### PR DESCRIPTION
## Summary
- update the live map readiness check to allow rendering markers when the world size is known
- fall back to player position samples when no map image is available so active players are still displayed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3befdf19c8331821c8e76d8651d85