### PR TITLE
Simplify chat entry layout

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -416,23 +416,41 @@
       if (entry.channel === 'team') li.classList.add('team');
       if (entry.id != null) li.dataset.messageId = String(entry.id);
       li.dataset.channel = entry.channel;
-      const header = document.createElement('div');
-      header.className = 'chat-entry-header';
+
+      const avatar = document.createElement('div');
+      avatar.className = 'chat-entry-avatar';
+      const baseName = (entry.username || entry.steamId || 'Unknown').trim();
+      const initial = baseName.charAt(0) || '?';
+      const avatarLabel = document.createElement('span');
+      avatarLabel.className = 'chat-entry-avatar-label';
+      avatarLabel.textContent = initial.toUpperCase();
+      if (entry.color) {
+        avatar.style.backgroundColor = entry.color;
+      }
+      avatar.appendChild(avatarLabel);
+
+      const content = document.createElement('div');
+      content.className = 'chat-entry-content';
+      const meta = document.createElement('div');
+      meta.className = 'chat-entry-meta';
       const nameEl = document.createElement('span');
       nameEl.className = 'chat-entry-name';
-      nameEl.textContent = entry.username || entry.steamId || 'Unknown';
+      nameEl.textContent = baseName;
       nameEl.style.color = entry.color || '';
-      header.appendChild(nameEl);
+      meta.appendChild(nameEl);
       if (entry.steamId) {
         const idEl = document.createElement('span');
         idEl.className = 'chat-entry-id';
         idEl.textContent = entry.steamId;
-        header.appendChild(idEl);
+        meta.appendChild(idEl);
       }
+
       const messageEl = document.createElement('p');
       messageEl.className = 'chat-entry-message';
       messageEl.textContent = entry.message;
-      li.append(header, messageEl);
+
+      content.append(meta, messageEl);
+      li.append(avatar, content);
       workspaceChatList.appendChild(li);
     });
   }

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1431,25 +1431,49 @@ button.menu-tab.active {
 }
 
 .chat-entry {
-  padding: 12px 16px;
-  border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.chat-entry.team {
-  border-color: rgba(59, 130, 246, 0.45);
-  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.18) inset;
-}
-
-.chat-entry-header {
   display: flex;
-  align-items: baseline;
-  gap: 10px;
-  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.chat-entry:last-child {
+  border-bottom: none;
+}
+
+.chat-entry-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.25);
+}
+
+.chat-entry-avatar-label {
+  pointer-events: none;
+}
+
+.chat-entry-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: clamp(240px, 100%, 640px);
+}
+
+.chat-entry-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   font-size: 0.85rem;
-  color: var(--muted-strong);
 }
 
 .chat-entry-name {
@@ -1465,10 +1489,24 @@ button.menu-tab.active {
 }
 
 .chat-entry-message {
-  margin: 6px 0 0;
+  margin: 4px 0 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--text);
+  line-height: 1.45;
+}
+
+.chat-entry.team {
+  border-left: 3px solid rgba(59, 130, 246, 0.45);
+  padding-left: calc(10px + 3px);
+}
+
+.chat-entry.team .chat-entry-name {
+  color: rgba(148, 202, 255, 0.95);
 }
 
 .chat-filter {


### PR DESCRIPTION
## Summary
- remove the bubble treatment from chat messages so entries read as clean DM rows
- add subtle separators and a team accent bar to maintain channel context without message bubbles

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e3bc5737948331b5478093ba3952bf