### PR TITLE
Fix live map viewport initialisation order

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -452,6 +452,10 @@
       layout.appendChild(mapView);
       layout.appendChild(sidebar);
 
+      const viewportSizeCache = new WeakMap();
+      let viewportSizeUpdateHandle = null;
+      let viewportSizeUpdateScheduled = false;
+
       scheduleViewportSizeUpdate({ immediate: true });
 
       const parentView = ctx.root?.closest?.('[data-view]');
@@ -524,9 +528,6 @@
       const MAP_SIZE_MIN = 260;
       const MAP_SIZE_MAX = 720;
       const MAP_SIZE_VERTICAL_MARGIN = 180;
-      const viewportSizeCache = new WeakMap();
-      let viewportSizeUpdateHandle = null;
-      let viewportSizeUpdateScheduled = false;
       const scheduleViewportAnimationFrame = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
         ? window.requestAnimationFrame.bind(window)
         : (fn) => setTimeout(fn, 16);


### PR DESCRIPTION
## Summary
- initialise the live map viewport scheduling state before the first size update to prevent runtime errors during module setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c1eac55083319e54ed6d19f94c48