### PR TITLE
Ensure live map viewport is registered before scheduling updates

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -452,7 +452,9 @@
       layout.appendChild(mapView);
       layout.appendChild(sidebar);
 
-      scheduleViewportSizeUpdate({ immediate: true });
+      const viewportSizeCache = new WeakMap();
+      let viewportSizeUpdateHandle = null;
+      let viewportSizeUpdateScheduled = false;
 
       const parentView = ctx.root?.closest?.('[data-view]');
       let visibilityObserver = null;
@@ -524,9 +526,6 @@
       const MAP_SIZE_MIN = 260;
       const MAP_SIZE_MAX = 720;
       const MAP_SIZE_VERTICAL_MARGIN = 180;
-      const viewportSizeCache = new WeakMap();
-      let viewportSizeUpdateHandle = null;
-      let viewportSizeUpdateScheduled = false;
       const scheduleViewportAnimationFrame = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
         ? window.requestAnimationFrame.bind(window)
         : (fn) => setTimeout(fn, 16);
@@ -563,6 +562,8 @@
         offsetX: 0,
         offsetY: 0
       };
+
+      scheduleViewportSizeUpdate({ immediate: true });
 
       const panState = {
         active: false,


### PR DESCRIPTION
## Summary
- move the initial live map viewport size scheduling to run after the viewport object is initialised

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c1eac55083319e54ed6d19f94c48