### PR TITLE
Expand live map dimensions

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -208,10 +208,10 @@ main.grid{
 }
 .map-wrap canvas{display:block; width:100%; height:100%; border-radius:12px}
 .map-layout{display:flex; flex-direction:column; gap:18px}
-.live-map-card .map-layout{max-width:960px;margin:0 auto}
-.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7); width:100%; min-height:clamp(260px,45vh,420px)}
-.map-view.map-view-dynamic{--map-size:clamp(260px,45vh,420px); width:min(100%, var(--map-size)); height:var(--map-size); min-height:0; max-height:none; aspect-ratio:1/1}
-.map-view.map-view-has-message{width:100%; min-height:clamp(240px,48vh,420px); height:auto}
+.live-map-card .map-layout{max-width:1280px;margin:0 auto}
+.map-view{position:relative; border-radius:12px; overflow:hidden; border:1px solid rgba(148,163,184,.12); background:rgba(8,10,16,.7); width:100%; min-height:clamp(400px,60vh,680px)}
+.map-view.map-view-dynamic{--map-size:clamp(400px,60vh,680px); width:min(100%, var(--map-size)); height:var(--map-size); min-height:0; max-height:none; aspect-ratio:1/1}
+.map-view.map-view-has-message{width:100%; min-height:clamp(340px,55vh,600px); height:auto}
 .map-view img{display:block; width:100%; height:auto}
 .map-placeholder{position:absolute; inset:0; display:none; align-items:center; justify-content:center; flex-direction:column; gap:18px; padding:32px 24px; text-align:center; background:rgba(15,23,42,.86); color:var(--muted); font-size:.96rem; line-height:1.5; z-index:2; overflow:auto}
 .map-overlay{position:absolute; inset:0; pointer-events:none; --marker-scale:1; z-index:3}
@@ -234,7 +234,7 @@ main.grid{
 .map-sidebar .row{display:flex; justify-content:flex-end}
 .map-sidebar .row button{border-radius:999px}
 .map-player-list{overflow-x:auto}
-.live-map-card .map-player-list{max-height:clamp(240px,48vh,520px); overflow-y:auto}
+.live-map-card .map-player-list{max-height:clamp(280px,54vh,640px); overflow-y:auto}
 .map-player-table{width:100%; min-width:420px; border-collapse:collapse; font-size:.9rem}
 .map-player-table thead th{
   text-align:left; font-size:.7rem; text-transform:uppercase; letter-spacing:.06em;

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2360,7 +2360,7 @@ button.chat-filter-btn:focus-visible {
 .map-layout {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 1fr);
+  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 1fr);
   gap: clamp(20px, 3vw, 32px);
   align-items: stretch;
   width: 100%;
@@ -2381,12 +2381,12 @@ button.chat-filter-btn:focus-visible {
   background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(30, 41, 59, 0.86) 100%);
   box-shadow: 0 32px 68px rgba(8, 13, 30, 0.55);
   width: 100%;
-  min-height: clamp(320px, 44vh, 520px);
+  min-height: clamp(420px, 60vh, 720px);
   transition: background 0.28s ease, border-color 0.28s ease, box-shadow 0.28s ease;
 }
 
 .map-view.map-view-dynamic {
-  --map-size: clamp(320px, 44vh, 520px);
+  --map-size: clamp(420px, 60vh, 720px);
   width: min(100%, var(--map-size));
   height: var(--map-size);
   min-height: 0;
@@ -2396,7 +2396,7 @@ button.chat-filter-btn:focus-visible {
 
 .map-view.map-view-has-message {
   width: 100%;
-  min-height: clamp(280px, 48vh, 520px);
+  min-height: clamp(340px, 55vh, 600px);
   height: auto;
 }
 
@@ -2438,7 +2438,7 @@ button.chat-filter-btn:focus-visible {
 }
 
 .live-map-card .map-view {
-  min-height: clamp(320px, 44vh, 520px);
+  min-height: clamp(420px, 60vh, 720px);
 }
 
 .map-placeholder {
@@ -2683,7 +2683,7 @@ button.chat-filter-btn:focus-visible {
 }
 
 .live-map-card .map-player-list {
-  max-height: clamp(240px, 48vh, 520px);
+  max-height: clamp(280px, 54vh, 640px);
   overflow-y: auto;
   padding: 12px;
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- increase the live map canvas sizing clamps so the viewport renders much larger by default
- widen the layout and raise the player list height cap to better match the expanded map area
- align the dark theme styles with the new dimensions, including a wider maximum layout width

## Testing
- not run (frontend-only CSS changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5a39a788331a312edc12b1e2480