### PR TITLE
Enhance chat entries with avatars and timestamps

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -1458,6 +1458,20 @@ button.menu-tab.active {
   box-shadow: 0 10px 18px rgba(15, 23, 42, 0.25);
 }
 
+.chat-entry-avatar.has-image {
+  background: transparent;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.2);
+  overflow: hidden;
+}
+
+.chat-entry-avatar img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
 .chat-entry-avatar-label {
   pointer-events: none;
 }
@@ -1472,13 +1486,48 @@ button.menu-tab.active {
 .chat-entry-meta {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
   font-size: 0.85rem;
+}
+
+.chat-entry-info {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .chat-entry-name {
   font-weight: 600;
   color: var(--text);
+  text-decoration: none;
+}
+
+.chat-entry-name:hover,
+.chat-entry-name:focus {
+  text-decoration: underline;
+}
+
+.chat-entry-channel {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.chat-entry.team .chat-entry-channel {
+  background: rgba(220, 38, 38, 0.15);
+  color: #b91c1c;
+}
+
+.chat-entry-timestamp {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .chat-entry-id {


### PR DESCRIPTION
## Summary
- parse additional chat payload fields and cache steam profile lookups for message authors
- render chat entries with profile avatars, channel badges, and hh:mm:ss timestamps linked to steam profiles when available
- update chat styling to support image avatars and refreshed metadata layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3c68d0a84833180ce78b66d506730