### PR TITLE
Expand live map viewport sizing

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -524,7 +524,7 @@
       let mapImageLocked = false;
 
       const MAP_SIZE_MIN = 260;
-      const MAP_SIZE_MAX = 1400;
+      const MAP_SIZE_MAX = 1600;
       const MAP_SIZE_VERTICAL_MARGIN = 96;
       const scheduleViewportAnimationFrame = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
         ? window.requestAnimationFrame.bind(window)
@@ -689,17 +689,7 @@
           return;
         }
 
-        const heightLimit = computeViewportHeightLimit();
-        if (!Number.isFinite(heightLimit) || heightLimit <= 0) {
-          if (previousInlineValue) {
-            mapElement.style.setProperty('--map-size', previousInlineValue);
-            mapElement.classList.add('map-view-dynamic');
-          } else if (Number.isFinite(previousSize)) {
-            mapElement.style.setProperty('--map-size', `${previousSize}px`);
-            mapElement.classList.add('map-view-dynamic');
-          }
-          return;
-        }
+        const heightLimit = computeViewportHeightLimit(width);
 
         let size = Math.min(width, heightLimit);
         if (width >= MAP_SIZE_MIN && heightLimit >= MAP_SIZE_MIN) {
@@ -720,7 +710,7 @@
         }
       }
 
-      function computeViewportHeightLimit() {
+      function computeViewportHeightLimit(desiredWidth) {
         const viewportHeight = typeof window !== 'undefined' ? Number(window.innerHeight) : NaN;
         let limit = Number.isFinite(viewportHeight) ? viewportHeight : MAP_SIZE_MAX;
         const layoutRect = typeof layout?.getBoundingClientRect === 'function' ? layout.getBoundingClientRect() : null;
@@ -728,6 +718,9 @@
           limit -= layoutRect.top;
         }
         limit -= MAP_SIZE_VERTICAL_MARGIN;
+        if (Number.isFinite(desiredWidth) && desiredWidth > 0) {
+          limit = Math.max(limit, desiredWidth);
+        }
         if (!Number.isFinite(limit)) {
           return MAP_SIZE_MAX;
         }

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2430,10 +2430,10 @@ button.chat-filter-btn:focus-visible {
 }
 
 .map-view.map-view-dynamic {
-  --map-size: clamp(420px, 70vh, 1200px);
+  --map-size: clamp(420px, 70vh, 1600px);
   width: 100%;
   max-width: var(--map-size);
-  align-self: center;
+  align-self: stretch;
 }
 
 .map-view.map-view-has-message {


### PR DESCRIPTION
## Summary
- ensure the live map sizing logic honours the available width and raises the maximum size so the canvas can fill the header space
- stretch the map view container styling so the rendered map no longer remains centered at a smaller size

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3cdd50b2c833199bb23b83ce3489f