### PR TITLE
Normalize monument icon tokens for map markers

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3013,7 +3013,22 @@ function monumentIconFromLabel(label, category) {
 function normaliseIconToken(value) {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
-  return trimmed || null;
+  if (!trimmed) return null;
+
+  const lowered = trimmed.toLowerCase();
+  const segment = lowered.split(/[\\/]/).pop();
+  const withoutQuery = segment.split(/[?#]/)[0];
+  const withoutExt = withoutQuery.replace(/\.[a-z0-9]+$/, '');
+  const normalized = withoutExt
+    .replace(/[_\s]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!normalized) return null;
+
+  const withoutSuffix = normalized.replace(/-\d+$/, '');
+  const cleaned = withoutSuffix.replace(/^(?:icon|monument|map)-/, '');
+  return cleaned || withoutSuffix || normalized;
 }
 
 function slugifyMonumentId(value, fallback) {


### PR DESCRIPTION
## Summary
- sanitize monument icon tokens from metadata so they match available map icon assets

## Testing
- node --check backend/src/index.js

------
https://chatgpt.com/codex/tasks/task_e_68e3d0bd38c08331a148e62d77daaafe