### PR TITLE
Add interactive team tiles to live map sidebar

### DIFF
--- a/frontend/assets/css/dark-theme.css
+++ b/frontend/assets/css/dark-theme.css
@@ -267,12 +267,16 @@ main.grid{
 .map-player-team{white-space:nowrap; font-size:.85rem; color:var(--muted-strong)}
 .map-player-stat{text-align:right; font-variant-numeric:tabular-nums}
 .map-filter-note{margin-top:8px}
-.map-team-info{display:flex; flex-direction:column; gap:10px; background:rgba(15,19,28,.78); border-radius:12px; padding:14px; border:1px solid rgba(148,163,184,.1)}
-.map-team-info .team-row{display:flex; align-items:center; justify-content:space-between; gap:12px; padding:4px 0}
-.map-team-info .team-label{display:inline-flex; align-items:center; gap:8px; font-weight:600; color:#e2e8f0}
-.map-team-info .team-detail{color:#cbd5f5; font-variant-numeric:tabular-nums}
-.map-team-info .team-row.active .team-detail{color:#f8fafc}
-.map-team-info .team-color{width:14px; height:14px; border-radius:50%; border:2px solid rgba(15,23,42,.6)}
+.map-team-info{display:flex; flex-direction:column; gap:12px; background:rgba(15,19,28,.78); border-radius:12px; padding:14px; border:1px solid rgba(148,163,184,.1)}
+.map-team-info .team-tile{background:rgba(15,23,42,.55); border:1px solid rgba(148,163,184,.16); color:#cbd5f5; transition:border-color .15s ease, box-shadow .15s ease, transform .15s ease}
+.map-team-info .team-tile:hover{border-color:rgba(148,163,184,.32); box-shadow:0 10px 26px rgba(2,6,23,.65); transform:translateY(-1px)}
+.map-team-info .team-tile:focus-visible{outline:2px solid var(--team-color, rgba(94,234,212,.75)); outline-offset:3px}
+.map-team-info .team-tile.active{border-color:var(--team-color, rgba(94,234,212,.75)); box-shadow:0 0 0 1px var(--team-color, rgba(94,234,212,.5)), 0 14px 32px rgba(2,6,23,.7)}
+.map-team-info .team-label{color:#f8fafc}
+.map-team-info .team-detail{color:#cbd5f5}
+.map-team-info .team-tile.active .team-detail{color:#f8fafc}
+.map-team-info .team-member-avatar{background:rgba(30,41,59,.8); color:#e2e8f0}
+.map-team-info .team-member-avatar.placeholder{background:rgba(226,232,240,.9); color:rgba(15,23,42,.85)}
 .map-color-chip{display:inline-block;width:14px;height:14px;border-radius:50%;border:2px solid rgba(15,23,42,.6);vertical-align:middle}
 .map-upload{border:1px dashed rgba(148,163,184,.25); border-radius:12px; padding:16px; background:rgba(17,20,30,.6); display:flex; flex-direction:column; gap:12px}
 .map-upload-actions{display:flex; gap:10px; flex-wrap:wrap}

--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -3560,32 +3560,94 @@
         updateRefreshDisplays();
       }
 
-      function createTeamInfoRow(viewport, options) {
+      function createTeamMember(viewport, player) {
         if (!viewport?.doc) return null;
-        const { label, detail, color, active = false } = options || {};
-        const row = viewport.doc.createElement('div');
-        row.className = 'team-row';
-        if (active) row.classList.add('active');
+        const member = viewport.doc.createElement('div');
+        member.className = 'team-member';
 
-        const left = viewport.doc.createElement('span');
-        left.className = 'team-label';
+        const avatarWrap = viewport.doc.createElement('div');
+        avatarWrap.className = 'team-member-avatar';
+        const avatarUrl = resolvePlayerAvatar(player);
+        const displayName = playerDisplayName(player);
+        if (avatarUrl) {
+          const img = viewport.doc.createElement('img');
+          img.src = avatarUrl;
+          img.alt = `${displayName} avatar`;
+          avatarWrap.appendChild(img);
+        } else {
+          avatarWrap.classList.add('placeholder');
+          avatarWrap.textContent = avatarInitial(displayName);
+        }
+
+        const meta = viewport.doc.createElement('div');
+        meta.className = 'team-member-meta';
+
+        const nameEl = viewport.doc.createElement('div');
+        nameEl.className = 'team-member-name';
+        nameEl.textContent = displayName;
+        meta.appendChild(nameEl);
+
+        const steamIdEl = viewport.doc.createElement('div');
+        steamIdEl.className = 'team-member-steamid';
+        steamIdEl.textContent = resolveSteamId(player) || '—';
+        meta.appendChild(steamIdEl);
+
+        member.appendChild(avatarWrap);
+        member.appendChild(meta);
+        return member;
+      }
+
+      function createTeamTile(viewport, options) {
+        if (!viewport?.doc) return null;
+        const { label, detail, members = [], color, active = false, teamId = null } = options || {};
+        const tile = viewport.doc.createElement('button');
+        tile.type = 'button';
+        tile.className = 'team-tile';
+        tile.setAttribute('aria-pressed', active ? 'true' : 'false');
+        if (active) tile.classList.add('active');
+        if (color) tile.style.setProperty('--team-color', color);
+        if (teamId != null) tile.dataset.teamId = String(teamId);
+
+        const header = viewport.doc.createElement('div');
+        header.className = 'team-tile-header';
+
+        const labelEl = viewport.doc.createElement('div');
+        labelEl.className = 'team-label';
         if (color) {
           const swatch = viewport.doc.createElement('span');
           swatch.className = 'map-color-chip';
           swatch.style.backgroundColor = color;
-          left.appendChild(swatch);
+          labelEl.appendChild(swatch);
         }
-        const labelEl = viewport.doc.createElement('span');
-        labelEl.textContent = label ?? '';
-        left.appendChild(labelEl);
+        const labelText = viewport.doc.createElement('span');
+        labelText.textContent = label ?? '';
+        labelEl.appendChild(labelText);
+        header.appendChild(labelEl);
 
-        const right = viewport.doc.createElement('span');
-        right.className = 'team-detail';
-        right.textContent = detail ?? '';
+        const detailEl = viewport.doc.createElement('span');
+        detailEl.className = 'team-detail';
+        if (detail != null) {
+          detailEl.textContent = detail;
+        } else if (members.length > 0) {
+          detailEl.textContent = `${members.length} player${members.length === 1 ? '' : 's'}`;
+        } else {
+          detailEl.textContent = 'No players';
+        }
+        header.appendChild(detailEl);
 
-        row.appendChild(left);
-        row.appendChild(right);
-        return row;
+        tile.appendChild(header);
+
+        if (members.length > 0) {
+          const list = viewport.doc.createElement('div');
+          list.className = 'team-members';
+          for (const player of members) {
+            const member = createTeamMember(viewport, player);
+            if (member) list.appendChild(member);
+          }
+          tile.appendChild(list);
+        }
+
+        return tile;
       }
 
       function renderTeamInfoInViewport(viewport) {
@@ -3600,14 +3662,21 @@
         if (state.selectedSolo) {
           const target = players.find((p) => resolveSteamId(p) === state.selectedSolo);
           if (!target) return;
-          const row = createTeamInfoRow(viewport, {
+          const tile = createTeamTile(viewport, {
             label: playerDisplayName(target),
             detail: 'Solo player',
+            members: [target],
             color: colorForPlayer(target),
-            active: true
+            active: true,
+            teamId: null
           });
-          if (row) container.appendChild(row);
-          container.classList.remove('hidden');
+          if (tile) {
+            tile.addEventListener('click', () => selectPlayer(target));
+            container.appendChild(tile);
+          }
+          if (container.childElementCount > 0) {
+            container.classList.remove('hidden');
+          }
           return;
         }
 
@@ -3624,13 +3693,25 @@
         const entries = [...teams.entries()].sort(([a], [b]) => a - b);
         for (const [teamId, members] of entries) {
           const color = state.teamColors.get(teamId) || colorForPlayer(members[0]);
-          const row = createTeamInfoRow(viewport, {
-            label: `Team ${teamId}`,
-            detail: `${members.length} player${members.length === 1 ? '' : 's'}`,
-            color,
-            active: state.selectedTeam === teamId
+          const sortedMembers = [...members].sort((a, b) => {
+            const nameA = playerDisplayName(a) || '';
+            const nameB = playerDisplayName(b) || '';
+            return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
           });
-          if (row) container.appendChild(row);
+          const tile = createTeamTile(viewport, {
+            label: `Team ${teamId}`,
+            members: sortedMembers,
+            color,
+            active: state.selectedTeam === teamId,
+            teamId
+          });
+          if (tile) {
+            tile.addEventListener('click', () => {
+              const primary = sortedMembers[0];
+              if (primary) selectPlayer(primary);
+            });
+            container.appendChild(tile);
+          }
         }
 
         if (container.childElementCount > 0) {

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -3213,14 +3213,49 @@ button.chat-filter-btn:focus-visible {
   border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--muted);
   font-size: 0.88rem;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.map-team-info .team-row {
+.map-team-info .team-tile {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.2);
+  padding: 12px;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.25;
+  outline: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.map-team-info .team-tile:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28);
+  transform: translateY(-1px);
+}
+
+.map-team-info .team-tile:focus-visible {
+  outline: 2px solid var(--team-color, rgba(59, 130, 246, 0.65));
+  outline-offset: 2px;
+}
+
+.map-team-info .team-tile.active {
+  border-color: var(--team-color, rgba(94, 234, 212, 0.6));
+  box-shadow: 0 0 0 1px var(--team-color, rgba(94, 234, 212, 0.4)), 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.map-team-info .team-tile-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 4px 0;
+  margin-bottom: 10px;
 }
 
 .map-team-info .team-label {
@@ -3229,15 +3264,80 @@ button.chat-filter-btn:focus-visible {
   gap: 8px;
   font-weight: 600;
   color: var(--text);
+  font-size: 0.95rem;
 }
 
 .map-team-info .team-detail {
   color: var(--muted-strong);
   font-variant-numeric: tabular-nums;
+  font-size: 0.85rem;
 }
 
-.map-team-info .team-row.active .team-detail {
+.map-team-info .team-tile.active .team-detail {
   color: var(--text);
+}
+
+.map-team-info .team-members {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.map-team-info .team-member {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.map-team-info .team-member-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text);
+}
+
+.map-team-info .team-member-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.map-team-info .team-member-avatar.placeholder {
+  color: rgba(15, 23, 42, 0.85);
+  background: rgba(226, 232, 240, 0.8);
+}
+
+.map-team-info .team-member-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.map-team-info .team-member-name {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.map-team-info .team-member-steamid {
+  color: var(--muted-strong);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .map-color-chip {


### PR DESCRIPTION
## Summary
- replace the live map team list with clickable tiles that render each member's avatar, name, and Steam ID
- wire tile clicks into the existing selection logic so teams and solo players can be highlighted from the sidebar
- refresh light and dark theme styles to support the new tile layout

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3d233d7dc833197d3f6be16907df2