### PR TITLE
Parse WebRCON chat JSON payloads

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -910,7 +910,8 @@ async function handleChatMessage(serverId, line, payload) {
     username: parsed.username || null,
     message: parsed.message,
     raw: parsed.raw || (typeof rawInput === 'string' ? rawInput : null),
-    color: parsed.color || null
+    color: parsed.color || null,
+    created_at: parsed.timestamp || null
   };
 
   let stored = null;
@@ -922,7 +923,7 @@ async function handleChatMessage(serverId, line, payload) {
     }
   }
 
-  const createdAt = stored?.created_at || new Date().toISOString();
+  const createdAt = stored?.created_at || parsed.timestamp || new Date().toISOString();
   const eventPayload = {
     id: stored?.id ?? null,
     serverId: key,


### PR DESCRIPTION
## Summary
- add helpers to normalise WebRCON chat channel and timestamp values
- parse JSON-formatted chat payloads to extract message metadata
- store parsed timestamps when recording chat history and emitting socket events

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e3f33c131c8331ab28e8394cfcc97d