### PR TITLE
Show persistent live map zoom hint

### DIFF
--- a/frontend/assets/modules/map.js
+++ b/frontend/assets/modules/map.js
@@ -636,11 +636,10 @@
       mapStage.appendChild(message);
 
       const interactionHint = document.createElement('div');
-      interactionHint.className = 'map-interaction-hint';
-      interactionHint.setAttribute('aria-hidden', 'true');
+      interactionHint.className = 'map-interaction-hint map-interaction-hint-visible';
       const interactionHintContent = document.createElement('div');
       interactionHintContent.className = 'map-interaction-hint-content';
-      interactionHintContent.textContent = 'Use Ctrl + scroll to zoom the map.';
+      interactionHintContent.textContent = 'Hold Ctrl and scroll to zoom the map.';
       interactionHint.appendChild(interactionHintContent);
       mapStage.appendChild(interactionHint);
       mapView.appendChild(mapStage);
@@ -834,12 +833,10 @@
       const zoomHintState = {
         attempts: 0,
         lastAttempt: 0,
-        timer: null,
-        visible: false
+        visible: true
       };
       const ZOOM_HINT_THRESHOLD = 3;
       const ZOOM_HINT_RESET_MS = 1200;
-      const ZOOM_HINT_DURATION_MS = 3500;
 
       let preventNextMapClick = false;
 
@@ -1185,26 +1182,17 @@
       }
 
       function hideInteractionHint() {
-        if (zoomHintState.timer) {
-          clearTimeout(zoomHintState.timer);
-          zoomHintState.timer = null;
-        }
-        if (!zoomHintState.visible || !interactionHint) return;
-        interactionHint.classList.remove('map-interaction-hint-visible');
-        interactionHint.setAttribute('aria-hidden', 'true');
-        zoomHintState.visible = false;
-      }
-
-      function showInteractionHint() {
-        if (!interactionHint || mapView.classList.contains('map-view-has-message')) return;
+        if (!interactionHint) return;
         interactionHint.classList.add('map-interaction-hint-visible');
         interactionHint.removeAttribute('aria-hidden');
         zoomHintState.visible = true;
-        if (zoomHintState.timer) clearTimeout(zoomHintState.timer);
-        zoomHintState.timer = setTimeout(() => {
-          zoomHintState.timer = null;
-          hideInteractionHint();
-        }, ZOOM_HINT_DURATION_MS);
+      }
+
+      function showInteractionHint() {
+        if (!interactionHint) return;
+        interactionHint.classList.add('map-interaction-hint-visible');
+        interactionHint.removeAttribute('aria-hidden');
+        zoomHintState.visible = true;
       }
 
       function updateMarkerScale() {

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -2505,20 +2505,17 @@ button.chat-filter-btn:focus-visible {
 
 .map-interaction-hint {
   position: absolute;
-  inset: 0;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px 24px;
-  text-align: center;
-  background: rgba(8, 11, 19, 0.82);
-  color: #e2e8f0;
-  font-size: 1rem;
-  line-height: 1.5;
-  opacity: 0;
+  padding: 0;
+  margin: 0;
   pointer-events: none;
-  transition: opacity 0.24s ease;
   z-index: 4;
+  opacity: 1;
 }
 
 .map-interaction-hint-visible {
@@ -2526,13 +2523,19 @@ button.chat-filter-btn:focus-visible {
 }
 
 .map-interaction-hint-content {
-  max-width: 420px;
-  padding: 20px 26px;
-  border-radius: 14px;
+  max-width: min(420px, 90vw);
+  padding: 10px 16px;
+  border-radius: 999px;
   background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  box-shadow: 0 22px 48px rgba(8, 13, 28, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 12px 28px rgba(8, 13, 28, 0.45);
+  color: #e2e8f0;
+  font-size: 0.92rem;
   font-weight: 600;
+  line-height: 1.4;
+  text-align: center;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(6px);
 }
 
 .map-placeholder-text {


### PR DESCRIPTION
## Summary
- keep the live map zoom hint visible as a non-blocking banner on the live map
- restyle the hint so it renders as a compact message at the top of the map instead of covering the viewport

## Testing
- manual: served the frontend locally via `python -m http.server 8000` and verified the banner renders while the map remains visible


------
https://chatgpt.com/codex/tasks/task_e_68e3f8b6503c8331b47214c5049b8164