### PR TITLE
Respect frontend imagery skip requests

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4941,7 +4941,10 @@ app.get('/api/servers/:id/live-map', auth, async (req, res) => {
       logger.warn('Server reported non-Facepunch level URL, treating as custom map', { levelUrl });
     }
     let hasCustomLevelUrl = isCustomLevelUrl(levelUrl);
-    const skipImageryFetch = skipImagery && hasCustomLevelUrl;
+    // The frontend only opts-in to skip imagery when it has already paused
+    // RustMaps polling for a custom map. Trust that signal so we don't keep
+    // hitting the external API and trigger its rate limits.
+    const skipImageryFetch = skipImagery;
     const derivedMapKey = deriveMapKey(info) || null;
     let infoMapKey = hasCustomLevelUrl ? null : derivedMapKey;
 


### PR DESCRIPTION
## Summary
- trust the frontend's `skipImagery` flag when serving live map requests so we stop polling RustMaps after the UI pauses checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4162d4e548331890947d5143115f7